### PR TITLE
[S2] 메인 및 하위 컴포넌트의 테스트 코드를 작성한다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.62.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tanstack/react-query": "^5.62.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "^18.3.13",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@eslint/js':
         specifier: ^9.16.0
         version: 9.16.0
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/react':
         specifier: ^18.3.13
         version: 18.3.13
@@ -59,7 +62,7 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.2)
+        version: 4.3.4(vite@6.0.2(@types/node@22.10.1))
       '@vitest/ui':
         specifier: ^2.1.8
         version: 2.1.8(vitest@2.1.8)
@@ -89,10 +92,10 @@ importers:
         version: 8.17.0(eslint@9.16.0)(typescript@5.6.3)
       vite:
         specifier: ^6.0.2
-        version: 6.0.2
+        version: 6.0.2(@types/node@22.10.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@vitest/ui@2.1.8)(jsdom@25.0.1)
+        version: 2.1.8(@types/node@22.10.1)(@vitest/ui@2.1.8)(jsdom@25.0.1)
 
 packages:
 
@@ -576,6 +579,18 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -699,6 +714,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@tanstack/query-core@5.62.2':
     resolution: {integrity: sha512-LcwVcC5qpsDpHcqlXUUL5o9SaOBwhNkGeV+B06s0GBoyBr8FqXPuXT29XzYXR36lchhnerp6XO+CWc84/vh7Zg==}
 
@@ -757,8 +775,23 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.10.1':
+    resolution: {integrity: sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -771,6 +804,15 @@ packages:
 
   '@types/react@18.3.13':
     resolution: {integrity: sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
   '@typescript-eslint/eslint-plugin@8.17.0':
     resolution: {integrity: sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==}
@@ -969,6 +1011,10 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1042,6 +1088,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -1074,6 +1124,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1138,6 +1192,10 @@ packages:
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1224,6 +1282,9 @@ packages:
     resolution: {integrity: sha512-49TewVEz0UxZjr1WYYsWpPrhyC/B/pA8Bq0fUmet2n+eR7yn0IvNzNaoBwnK6mdkzcN+se7Ez9zUgULTz2QH4g==}
     engines: {node: '>=18'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -1297,6 +1358,26 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1494,6 +1575,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1519,6 +1604,9 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -1622,6 +1710,10 @@ packages:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1629,6 +1721,10 @@ packages:
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1734,6 +1830,9 @@ packages:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
@@ -2328,6 +2427,23 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1': {}
 
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.10.1
+      '@types/yargs': 17.0.33
+      chalk: 4.1.2
+
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -2413,6 +2529,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.28.0':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@tanstack/query-core@5.62.2': {}
 
   '@tanstack/react-query@5.62.2(react@18.3.1)':
@@ -2482,7 +2600,26 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.10.1':
+    dependencies:
+      undici-types: 6.20.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -2496,6 +2633,14 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.13
       csstype: 3.1.3
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0)(typescript@5.6.3))(eslint@9.16.0)(typescript@5.6.3)':
     dependencies:
@@ -2579,14 +2724,14 @@ snapshots:
       '@typescript-eslint/types': 8.17.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.2)':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.2(@types/node@22.10.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.2
+      vite: 6.0.2(@types/node@22.10.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2597,13 +2742,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11)':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.1))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
-      vite: 5.4.11
+      vite: 5.4.11(@types/node@22.10.1)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -2633,7 +2778,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@vitest/ui@2.1.8)(jsdom@25.0.1)
+      vitest: 2.1.8(@types/node@22.10.1)(@vitest/ui@2.1.8)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.8':
     dependencies:
@@ -2734,6 +2879,8 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  ci-info@3.9.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2792,6 +2939,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  diff-sequences@29.6.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -2861,6 +3010,8 @@ snapshots:
       '@esbuild/win32-x64': 0.24.0
 
   escalade@3.2.0: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2944,6 +3095,14 @@ snapshots:
 
   expect-type@1.1.0: {}
 
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.2:
@@ -3017,6 +3176,8 @@ snapshots:
 
   globals@15.13.0: {}
 
+  graceful-fs@4.2.11: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
@@ -3083,6 +3244,43 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.10.1
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
 
   js-tokens@4.0.0: {}
 
@@ -3266,6 +3464,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -3288,6 +3492,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-refresh@0.14.2: {}
 
@@ -3395,9 +3601,15 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -3479,6 +3691,8 @@ snapshots:
 
   typescript@5.6.3: {}
 
+  undici-types@6.20.0: {}
+
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
       browserslist: 4.24.2
@@ -3489,13 +3703,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@2.1.8:
+  vite-node@2.1.8(@types/node@22.10.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11
+      vite: 5.4.11(@types/node@22.10.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3507,26 +3721,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11:
+  vite@5.4.11(@types/node@22.10.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.28.0
     optionalDependencies:
+      '@types/node': 22.10.1
       fsevents: 2.3.3
 
-  vite@6.0.2:
+  vite@6.0.2(@types/node@22.10.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.28.0
     optionalDependencies:
+      '@types/node': 22.10.1
       fsevents: 2.3.3
 
-  vitest@2.1.8(@vitest/ui@2.1.8)(jsdom@25.0.1):
+  vitest@2.1.8(@types/node@22.10.1)(@vitest/ui@2.1.8)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11)
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.1))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -3542,10 +3758,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11
-      vite-node: 2.1.8
+      vite: 5.4.11(@types/node@22.10.1)
+      vite-node: 2.1.8(@types/node@22.10.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 22.10.1
       '@vitest/ui': 2.1.8(vitest@2.1.8)
       jsdom: 25.0.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.5.2(@testing-library/dom@10.4.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -747,12 +744,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@testing-library/user-event@14.5.2':
-    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2568,10 +2559,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.13
       '@types/react-dom': 18.3.1
-
-  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
-    dependencies:
-      '@testing-library/dom': 10.4.0
 
   '@types/aria-query@5.0.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -726,6 +729,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2441,6 +2450,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.13
       '@types/react-dom': 18.3.1
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@types/aria-query@5.0.4': {}
 

--- a/src/components/Studio/StudioItem.tsx
+++ b/src/components/Studio/StudioItem.tsx
@@ -3,18 +3,14 @@ import ImageSwiper from '@components/ImageSwiper/ImageSwiper';
 import styled from '@emotion/styled';
 import { Hidden, TypoTitleSmS } from '@styles/Common';
 import variables from '@styles/Variables';
-import { useState } from 'react';
 import { IMenus, IPortfolio, IStudioItem } from 'types/types';
 
 const StudioItem = ({ item, isFirst, isLast }: { item: IStudioItem; isFirst: boolean; isLast: boolean }) => {
-  const [hasLiked, setHasLiked] = useState<boolean>(false);
   // 북마크 설정/해제 api 호출
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation;
 
-    setHasLiked((state) => !state);
-
-    console.log('북마크 설정!');
+    console.log(`북마크 ${item.bookmark ? '해제' : '설정'}`);
   };
 
   // 최저가 계산 함수
@@ -73,8 +69,8 @@ const StudioItem = ({ item, isFirst, isLast }: { item: IStudioItem; isFirst: boo
         </ItemInfoStyle>
         <BookmarkStyle>
           <button onClick={handleClick}>
-            <img src={`/img/icon-bookmark-${hasLiked ? 'active' : 'inactive'}.svg`} alt={`북마크 ${hasLiked ? '해제' : '등록'}`} />
-            <span css={Hidden}>북마크 {`${hasLiked ? '해제' : '등록'}하기`}</span>
+            <img src={`/img/icon-bookmark-${item.bookmark ? 'active' : 'inactive'}.svg`} alt={`북마크 ${item.bookmark ? '해제' : '등록'}`} />
+            <span css={Hidden}>북마크 {`${item.bookmark ? '해제' : '등록'}하기`}</span>
           </button>
           <p>{item.bookmark_count}</p>
         </BookmarkStyle>

--- a/src/components/Studio/StudioList.tsx
+++ b/src/components/Studio/StudioList.tsx
@@ -1,10 +1,10 @@
+import EmptyMessage from '@components/Message/EmptyMessage';
 import { useGetStudios } from '@hooks/useGetStudios';
 import { decodeSearchParamsToString } from '@utils/decodeSearchParams';
 import { useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { IStudioItem } from 'types/types';
 import StudioItem from './StudioItem';
-import EmptyMessage from '@components/Message/EmptyMessage';
 
 const StudioList = ({ mode, searchParams }: { mode: 'filter' | 'search/result'; searchParams: URLSearchParams }) => {
   const params = decodeSearchParamsToString(searchParams);
@@ -38,23 +38,17 @@ const StudioList = ({ mode, searchParams }: { mode: 'filter' | 'search/result'; 
 
   return (
     <>
-      {isLoading && isFetching ? (
-        <div>로딩 컴포넌트!</div>
+      {data?.content.length === 0 ? (
+        <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} />
       ) : (
-        <>
-          {data?.content.length === 0 ? (
-            <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} />
-          ) : (
-            <Virtuoso
-              data={items}
-              useWindowScroll
-              totalCount={items.length}
-              endReached={loadMore}
-              overscan={10}
-              itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
-            />
-          )}
-        </>
+        <Virtuoso
+          data={items}
+          useWindowScroll
+          totalCount={items.length}
+          endReached={loadMore}
+          overscan={10}
+          itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
+        />
       )}
     </>
   );

--- a/src/components/Studio/StudioList.tsx
+++ b/src/components/Studio/StudioList.tsx
@@ -38,17 +38,23 @@ const StudioList = ({ mode, searchParams }: { mode: 'filter' | 'search/result'; 
 
   return (
     <>
-      {data?.content.length === 0 ? (
-        <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} />
+      {pageNum === 0 && isLoading ? (
+        <div>로딩중</div>
       ) : (
-        <Virtuoso
-          data={items}
-          useWindowScroll
-          totalCount={items.length}
-          endReached={loadMore}
-          overscan={10}
-          itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
-        />
+        <>
+          {data?.content.length === 0 ? (
+            <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} />
+          ) : (
+            <Virtuoso
+              data={items}
+              useWindowScroll
+              totalCount={items.length}
+              endReached={loadMore}
+              overscan={10}
+              itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/components/Studio/StudioList.tsx
+++ b/src/components/Studio/StudioList.tsx
@@ -36,23 +36,25 @@ const StudioList = ({ mode, searchParams }: { mode: 'filter' | 'search/result'; 
     }
   };
 
-  const isSearchResultEmpty = () => {
-    return mode === 'search/result' && (!data?.content || data.content.length === 0);
-  };
-
   return (
     <>
-      {isSearchResultEmpty() ? (
-        <EmptyMessage message="검색 결과가 없습니다." />
+      {isLoading && isFetching ? (
+        <div>로딩 컴포넌트!</div>
       ) : (
-        <Virtuoso
-          data={items}
-          useWindowScroll
-          totalCount={items.length}
-          endReached={loadMore}
-          overscan={10}
-          itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
-        />
+        <>
+          {data?.content.length === 0 ? (
+            <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} />
+          ) : (
+            <Virtuoso
+              data={items}
+              useWindowScroll
+              totalCount={items.length}
+              endReached={loadMore}
+              overscan={10}
+              itemContent={(index, item) => <StudioItem key={item.id} item={item} isFirst={index === 0} isLast={index === items.length - 1} />}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/src/tests/Home.test.tsx
+++ b/src/tests/Home.test.tsx
@@ -1,10 +1,65 @@
-// Test Code Sample - 실제 코드 생성 후 삭제해주세요
+import Home from '@pages/Home/Home';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, test, vi } from 'vitest';
 
-import { describe, expect, it } from 'vitest';
+const openBottomSheetMock = vi.fn();
 
-// test 오류로 빈 파일에 임시 더미 코드 작성해둔것임!
-describe('Placeholder test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
+// useBottomSheetState의 default export: useBottonSheetState를 vi.fn()으로 Mock => 내부에 openBottomSheet Action Mock
+vi.mock('@store/useBottomSheetStateStroe', () => ({
+  default: vi.fn(() => ({
+    openBottomSheet: openBottomSheetMock,
+  })),
+}));
+
+describe('Home Component', () => {
+  const queryClient = new QueryClient();
+
+  const renderWithQueryClient = (children: React.ReactNode, { route = '/' } = {}) =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+  // 테스트 전 모든 Mock 초기화
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('Home 컴포넌트와 하위 컴포넌트들을 렌더링해야 합니다.', () => {
+    renderWithQueryClient(<Home />, { route: '/' });
+    expect(screen.findByAltText(/필터 초기화/i));
+    expect(screen.getByText('인기순')).toBeInTheDocument();
+    expect(screen.getByText('가격대')).toBeInTheDocument();
+    expect(screen.getByText('매장정보')).toBeInTheDocument();
+  });
+
+  test('Home 컴포넌트의 스크롤이 -78px이 되면 Navigator의 position을 fixed로 설정해야 합니다.', () => {
+    renderWithQueryClient(<Home />, { route: '/' });
+    const scrollEvent = new Event('scroll');
+    window.dispatchEvent(scrollEvent);
+
+    waitFor(() => {
+      const navigator = screen.getByText('몽환').closest('div');
+      expect(navigator).toHaveStyle('position: fixed');
+    });
+  });
+
+  test('필터 버튼을 누르면 바텀시트를 오픈해야 합니다.', () => {
+    renderWithQueryClient(<Home />, { route: '/' });
+
+    // 인기순 버튼 클릭
+    fireEvent.click(screen.getByText('인기순'));
+    expect(openBottomSheetMock).toHaveBeenCalledWith(expect.anything(), '정렬');
+
+    // 가격대 버튼 클릭
+    fireEvent.click(screen.getByText('가격대'));
+    expect(openBottomSheetMock).toHaveBeenCalledWith(expect.anything(), '가격');
+
+    // 매장정보 버튼 클릭
+    fireEvent.click(screen.getByText('매장정보'));
+    expect(openBottomSheetMock).toHaveBeenCalledWith(expect.anything(), '매장정보');
   });
 });

--- a/src/tests/StudioItem.test.tsx
+++ b/src/tests/StudioItem.test.tsx
@@ -1,0 +1,199 @@
+import StudioItem from '@components/Studio/StudioItem';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IStudioItem } from 'types/types';
+import { describe, expect, test } from 'vitest';
+
+const mockStudio: IStudioItem = {
+  id: 146,
+  vibe: '시크',
+  addressSi: '서울시',
+  addressGu: '성북구',
+  name: '주 스튜디오',
+  description: 'this is sample description_36',
+  address: '동소문로 35 2층',
+  phone: '010-0000-0035',
+  view_count: 206,
+  rating: 3.2,
+  bookmark_count: 297,
+  review_count: 278,
+  latitude: null,
+  longitude: null,
+  open_time: '09:00:00',
+  close_time: '18:00:00',
+  subVibe: '선명한',
+  portfolios: [
+    {
+      id: 182,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_182',
+      url: 'https://i.imgur.com/BMDwLgQ.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 183,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_183',
+      url: 'https://i.imgur.com/7C4GSF4.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 184,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_184',
+      url: 'https://i.imgur.com/yjmxVej.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 185,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_185',
+      url: 'https://i.imgur.com/zwoRb86.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 186,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_186',
+      url: 'https://i.imgur.com/HWtmnvf.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 187,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_187',
+      url: 'https://i.imgur.com/6lMAQjA.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 188,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_188',
+      url: 'https://i.imgur.com/FcjS6Rd.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+    {
+      id: 189,
+      studio: '주 스튜디오',
+      vibe: '시크',
+      name: '주스 스튜디오_Vibe_2_189',
+      url: 'https://i.imgur.com/tPl867U.jpeg',
+      description: 'this is sample description',
+      created_at: '2024-12-03T21:02:58',
+      updated_at: null,
+    },
+  ],
+  menus: [
+    {
+      id: 71,
+      studio: '주 스튜디오',
+      name: '증명사진',
+      description: '증명사진에 대한 설명입니다.',
+      price: 31000,
+      created_at: null,
+      updated_at: null,
+    },
+    {
+      id: 72,
+      studio: '주 스튜디오',
+      name: '프로필사진',
+      description: '프로필사진에 대한 설명입니다.',
+      price: 140000,
+      created_at: null,
+      updated_at: null,
+    },
+  ],
+  options: [],
+  created_at: null,
+  updated_at: null,
+  day_of_week: 'MON',
+  bookmark: true,
+};
+
+describe('StudioItem Component', () => {
+  test('스튜디오 정보를 출력해야 합니다.', () => {
+    render(<StudioItem item={mockStudio} isFirst={false} isLast={false} />);
+
+    // 스튜디오 이름
+    expect(screen.findByText('주 스튜디오'));
+    // 스튜디오 평점
+    expect(screen.findByText('3.2'));
+
+    // 스튜디오 후기 수
+    expect(screen.findByText('278개의 평가'));
+
+    // 스튜디오 주소
+    expect(screen.findByText('성북구 동소문로 35 2층'));
+
+    // 스튜디오 영업 시간
+    expect(screen.findByText('09:00 - 18:00'));
+  });
+
+  test('메뉴 중 최저가를 계산해야 합니다.', () => {
+    render(<StudioItem item={mockStudio} isFirst={false} isLast={false} />);
+
+    // 스튜디오 최저가 계산
+    expect(screen.findByText('31000원~'));
+  });
+
+  test('북마크 설정 여부를 렌더링해야 합니다.', () => {
+    render(<StudioItem item={mockStudio} isFirst={false} isLast={false} />);
+
+    // 북마크 버튼
+    const bookmarkButton = screen.getByRole('button', { name: /북마크 해제하기/i });
+    expect(bookmarkButton).toBeInTheDocument();
+
+    // 스튜디오 북마크 수
+    expect(screen.findByText('297'));
+  });
+
+  test('북마크 버튼 클릭 시 북마크 설정 여부를 변경해야 합니다.', () => {
+    render(<StudioItem item={mockStudio} isFirst={false} isLast={false} />);
+
+    // 북마크 버튼
+    const bookmarkButton = screen.getByRole('button', { name: /북마크 해제하기/i });
+    expect(bookmarkButton).toBeInTheDocument();
+
+    // 초기 상태: 북마크 해제
+    expect(screen.findByText('북마크 해제'));
+
+    // 버튼 클릭
+    fireEvent.click(bookmarkButton);
+
+    // 변경 상태: 북마크 설정
+    expect(screen.findByText('북마크 등록'));
+  });
+
+  test('이미지 슬라이더에 이미지를 최대 5개 렌더링해야 합니다.', () => {
+    render(<StudioItem item={mockStudio} isFirst={false} isLast={false} />);
+
+    const images = screen.getAllByAltText(/이미지/i); // alt 속성을 이용한 이미지 찾기
+    expect(images.length).toBeLessThanOrEqual(5);
+
+    expect(images[0]).toHaveAttribute('src', 'https://i.imgur.com/BMDwLgQ.jpeg');
+    expect(images[1]).toHaveAttribute('src', 'https://i.imgur.com/7C4GSF4.jpeg');
+    expect(images[2]).toHaveAttribute('src', 'https://i.imgur.com/yjmxVej.jpeg');
+    expect(images[3]).toHaveAttribute('src', 'https://i.imgur.com/zwoRb86.jpeg');
+    expect(images[4]).toHaveAttribute('src', 'https://i.imgur.com/HWtmnvf.jpeg');
+  });
+});

--- a/src/tests/StudioList.test.tsx
+++ b/src/tests/StudioList.test.tsx
@@ -432,7 +432,7 @@ const mockedMoreStudios: IStudioRes = {
   empty: false,
 };
 
-describe('StudioList Components', () => {
+describe('StudioList Component', () => {
   test('스튜디오 리스트를 출력해야 합니다.', () => {
     // useGetStudios Mock 구현
     (useGetStudios as jest.Mock).mockReturnValue({
@@ -444,8 +444,8 @@ describe('StudioList Components', () => {
     render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
 
     // findByText: 비동기적으로 동작 => 데이터가 렌더링될 때까지 대기
-    screen.findByText(/주 스튜디오/i);
-    screen.findByText(/미에르스튜디오/i);
+    expect(screen.findByText(/주 스튜디오/i));
+    expect(screen.findByText(/미에르스튜디오/i));
   });
 
   test('스크롤을 끝까지 내리면 새로운 스튜디오 리스트를 로드해야 합니다.', () => {
@@ -457,8 +457,8 @@ describe('StudioList Components', () => {
 
     render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
 
-    screen.findByText(/주 스튜디오/i);
-    screen.findByText(/미에르스튜디오/i);
+    expect(screen.findByText(/주 스튜디오/i));
+    expect(screen.findByText(/미에르스튜디오/i));
 
     // 스크롤을 끝까지 내리는 시뮬레이션 (데이터가 끝에 도달하면)
     const virtuosoContainer = screen.getByTestId('virtuoso-container');
@@ -473,8 +473,8 @@ describe('StudioList Components', () => {
       isFetching: false,
     } as UseQueryResult<IStudioRes>);
 
-    screen.findByText(/오리우스씨네페이시스/i);
-    screen.findByText(/수상한 사진관/i);
+    expect(screen.findByText(/오리우스씨네페이시스/i));
+    expect(screen.findByText(/수상한 사진관/i));
   });
 
   test('데이터를 로딩 중일 때 로딩 컴포넌트를 출력해야 합니다.', () => {
@@ -487,7 +487,7 @@ describe('StudioList Components', () => {
     render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
 
     // 로딩 메시지가 화면에 표시되는지 확인
-    screen.findByText(/로딩 컴포넌트!/i);
+    expect(screen.findByText(/로딩 컴포넌트!/i));
   });
 
   test('검색 결과가 없을 때 "EmptyMessage" 컴포넌트를 출력해야 합니다.', () => {
@@ -501,6 +501,6 @@ describe('StudioList Components', () => {
     render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
 
     // 로딩 메시지가 화면에 표시되는지 확인
-    screen.findByText(/스튜디오 조회 결과가 없습니다./i);
+    expect(screen.findByText(/스튜디오 조회 결과가 없습니다./i));
   });
 });

--- a/src/tests/StudioList.test.tsx
+++ b/src/tests/StudioList.test.tsx
@@ -1,0 +1,506 @@
+import StudioList from '@components/Studio/StudioList';
+import { useGetStudios } from '@hooks/useGetStudios';
+import { UseQueryResult } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IStudioRes } from 'types/types';
+import { describe, test, vi } from 'vitest';
+
+// Virtuoso - Mock 처리
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, endReached, itemContent }: any) => (
+    <div
+      data-testid="virtuoso-container"
+      style={{ height: '500px', overflowY: 'scroll' }}
+      onScroll={() => {
+        // 스크롤이 끝에 도달했을 때 endReached 호출
+        if (endReached) endReached();
+      }}
+    >
+      {data.map((item: any, index: number) => (
+        <div key={item.id} data-testid="studio-item">
+          {itemContent(index, item)}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+// useGetStudio hook - Mock 처리
+vi.mock('@hooks/useGetStudios', () => ({
+  useGetStudios: vi.fn(),
+}));
+
+const mockedStudios: IStudioRes = {
+  content: [
+    {
+      id: 146,
+      vibe: '시크',
+      addressSi: '서울시',
+      addressGu: '성북구',
+      name: '주 스튜디오',
+      description: 'this is sample description_36',
+      address: '동소문로 35 2층',
+      phone: '010-0000-0035',
+      view_count: 206,
+      rating: 3.2,
+      bookmark_count: 297,
+      review_count: 278,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '선명한',
+      portfolios: [
+        {
+          id: 182,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_182',
+          url: 'https://i.imgur.com/BMDwLgQ.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 183,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_183',
+          url: 'https://i.imgur.com/7C4GSF4.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 184,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_184',
+          url: 'https://i.imgur.com/yjmxVej.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 185,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_185',
+          url: 'https://i.imgur.com/zwoRb86.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 186,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_186',
+          url: 'https://i.imgur.com/HWtmnvf.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 187,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_187',
+          url: 'https://i.imgur.com/6lMAQjA.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 188,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_188',
+          url: 'https://i.imgur.com/FcjS6Rd.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 189,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_189',
+          url: 'https://i.imgur.com/tPl867U.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+      ],
+      menus: [
+        {
+          id: 71,
+          studio: '주 스튜디오',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 31000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 72,
+          studio: '주 스튜디오',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 140000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'MON',
+      bookmark: true,
+    },
+    {
+      id: 175,
+      vibe: '청순',
+      addressSi: '서울시',
+      addressGu: '광진구',
+      name: '미에르스튜디오',
+      description: 'this is sample description_67',
+      address: '자양동 653-5 3층',
+      phone: '010-0000-0066',
+      view_count: 70,
+      rating: 4.1,
+      bookmark_count: 291,
+      review_count: 42,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '상큼',
+      portfolios: [],
+      menus: [
+        {
+          id: 129,
+          studio: '미에르스튜디오',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 40000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 130,
+          studio: '미에르스튜디오',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 150000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'THU',
+      bookmark: false,
+    },
+  ],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 20,
+    sort: {
+      empty: true,
+      sorted: false,
+      unsorted: true,
+    },
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  totalPages: 1,
+  totalElements: 2,
+  last: false,
+  size: 20,
+  number: 0,
+  sort: {
+    empty: true,
+    sorted: false,
+    unsorted: true,
+  },
+  numberOfElements: 2,
+  first: true,
+  empty: false,
+};
+
+const mockedMoreStudios: IStudioRes = {
+  content: [
+    {
+      id: 147,
+      vibe: '시크',
+      addressSi: '서울시',
+      addressGu: '금천구',
+      name: '오리우스씨네페이시스',
+      description: 'this is sample description_37',
+      address: '가산디지털1로 142 가산 더 스카이밸리 1차 지하1층 111호',
+      phone: '010-0000-0036',
+      view_count: 21,
+      rating: 4.6,
+      bookmark_count: 230,
+      review_count: 112,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '시크',
+      portfolios: [
+        {
+          id: 190,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_190',
+          url: 'https://i.imgur.com/P13qEQ3.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 191,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_191',
+          url: 'https://i.imgur.com/w1Eq9LG.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 192,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_192',
+          url: 'https://i.imgur.com/Gu4LFcB.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 193,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_193',
+          url: 'https://i.imgur.com/C9Vx3Xa.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 194,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_194',
+          url: 'https://i.imgur.com/7F9kdG7.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 195,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_195',
+          url: 'https://i.imgur.com/4JwTJwh.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 196,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_196',
+          url: 'https://i.imgur.com/BSS477l.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 197,
+          studio: '오리우스씨네페이시스',
+          vibe: '시크',
+          name: '오리우스씨네페이시스_Vibe_2_197',
+          url: 'https://i.imgur.com/qqteDsx.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+      ],
+      menus: [
+        {
+          id: 73,
+          studio: '오리우스씨네페이시스',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 41000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 74,
+          studio: '오리우스씨네페이시스',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 165000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'TUE',
+      bookmark: false,
+    },
+    {
+      id: 189,
+      vibe: '청순',
+      addressSi: '서울시',
+      addressGu: '마포구',
+      name: '수상한 사진관',
+      description: 'this is sample description_81',
+      address: '홍익로6길 23 B1',
+      phone: '010-0000-0080',
+      view_count: 290,
+      rating: 0.9,
+      bookmark_count: 230,
+      review_count: 191,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '선명한',
+      portfolios: [],
+      menus: [
+        {
+          id: 157,
+          studio: '수상한 사진관',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 49000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 158,
+          studio: '수상한 사진관',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 140000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'THU',
+      bookmark: false,
+    },
+  ],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 20,
+    sort: {
+      empty: true,
+      sorted: false,
+      unsorted: true,
+    },
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  totalPages: 1,
+  totalElements: 2,
+  last: false,
+  size: 20,
+  number: 0,
+  sort: {
+    empty: true,
+    sorted: false,
+    unsorted: true,
+  },
+  numberOfElements: 2,
+  first: true,
+  empty: false,
+};
+
+describe('StudioList Components', () => {
+  test('스튜디오 리스트를 출력해야 합니다.', () => {
+    // useGetStudios Mock 구현
+    (useGetStudios as jest.Mock).mockReturnValue({
+      data: mockedStudios,
+      isLoading: false,
+      isFetching: false,
+    } as UseQueryResult<IStudioRes>);
+
+    render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
+
+    // findByText: 비동기적으로 동작 => 데이터가 렌더링될 때까지 대기
+    screen.findByText(/주 스튜디오/i);
+    screen.findByText(/미에르스튜디오/i);
+  });
+
+  test('스크롤을 끝까지 내리면 새로운 스튜디오 리스트를 로드해야 합니다.', () => {
+    (useGetStudios as jest.Mock).mockReturnValue({
+      data: mockedStudios,
+      isLoading: false,
+      isFetching: false,
+    } as UseQueryResult<IStudioRes>);
+
+    render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
+
+    screen.findByText(/주 스튜디오/i);
+    screen.findByText(/미에르스튜디오/i);
+
+    // 스크롤을 끝까지 내리는 시뮬레이션 (데이터가 끝에 도달하면)
+    const virtuosoContainer = screen.getByTestId('virtuoso-container');
+    fireEvent.scroll(virtuosoContainer, {
+      target: { scrollY: virtuosoContainer.scrollHeight },
+    });
+
+    // 스크롤이 하단에 닿으면 Load More 후 새로운 스튜디오 리스트를 Mock 처리
+    (useGetStudios as jest.Mock).mockReturnValueOnce({
+      data: mockedMoreStudios,
+      isLoading: false,
+      isFetching: false,
+    } as UseQueryResult<IStudioRes>);
+
+    screen.findByText(/오리우스씨네페이시스/i);
+    screen.findByText(/수상한 사진관/i);
+  });
+
+  test('데이터를 로딩 중일 때 로딩 컴포넌트를 출력해야 합니다.', () => {
+    // Loading & Fetching의 경우
+    (useGetStudios as jest.Mock).mockReturnValueOnce({
+      isLoading: true,
+      isFetching: true,
+    } as UseQueryResult<IStudioRes | null>);
+
+    render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
+
+    // 로딩 메시지가 화면에 표시되는지 확인
+    screen.findByText(/로딩 컴포넌트!/i);
+  });
+
+  test('검색 결과가 없을 때 "EmptyMessage" 컴포넌트를 출력해야 합니다.', () => {
+    // 데이터가 없는 경우
+    (useGetStudios as jest.Mock).mockReturnValueOnce({
+      data: null,
+      isLoading: false,
+      isFetching: false,
+    } as UseQueryResult<IStudioRes | null>);
+
+    render(<StudioList mode="filter" searchParams={new URLSearchParams()} />);
+
+    // 로딩 메시지가 화면에 표시되는지 확인
+    screen.findByText(/스튜디오 조회 결과가 없습니다./i);
+  });
+});

--- a/src/tests/useGetStudios.test.tsx
+++ b/src/tests/useGetStudios.test.tsx
@@ -1,0 +1,270 @@
+import { useGetStudios } from '@hooks/useGetStudios';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, renderHook, waitFor } from '@testing-library/react';
+import { IStudioRes } from 'types/types';
+import { describe, test, vi } from 'vitest';
+
+// Response - Mock 처리
+const mockedStudios: IStudioRes = {
+  content: [
+    {
+      id: 146,
+      vibe: '시크',
+      addressSi: '서울시',
+      addressGu: '성북구',
+      name: '주 스튜디오',
+      description: 'this is sample description_36',
+      address: '동소문로 35 2층',
+      phone: '010-0000-0035',
+      view_count: 206,
+      rating: 3.2,
+      bookmark_count: 297,
+      review_count: 278,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '선명한',
+      portfolios: [
+        {
+          id: 182,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_182',
+          url: 'https://i.imgur.com/BMDwLgQ.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 183,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_183',
+          url: 'https://i.imgur.com/7C4GSF4.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 184,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_184',
+          url: 'https://i.imgur.com/yjmxVej.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 185,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_185',
+          url: 'https://i.imgur.com/zwoRb86.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 186,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_186',
+          url: 'https://i.imgur.com/HWtmnvf.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 187,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_187',
+          url: 'https://i.imgur.com/6lMAQjA.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 188,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_188',
+          url: 'https://i.imgur.com/FcjS6Rd.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+        {
+          id: 189,
+          studio: '주 스튜디오',
+          vibe: '시크',
+          name: '주스 스튜디오_Vibe_2_189',
+          url: 'https://i.imgur.com/tPl867U.jpeg',
+          description: 'this is sample description',
+          created_at: '2024-12-03T21:02:58',
+          updated_at: null,
+        },
+      ],
+      menus: [
+        {
+          id: 71,
+          studio: '주 스튜디오',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 31000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 72,
+          studio: '주 스튜디오',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 140000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'MON',
+      bookmark: true,
+    },
+    {
+      id: 175,
+      vibe: '청순',
+      addressSi: '서울시',
+      addressGu: '광진구',
+      name: '미에르스튜디오',
+      description: 'this is sample description_67',
+      address: '자양동 653-5 3층',
+      phone: '010-0000-0066',
+      view_count: 70,
+      rating: 4.1,
+      bookmark_count: 291,
+      review_count: 42,
+      latitude: null,
+      longitude: null,
+      open_time: '09:00:00',
+      close_time: '18:00:00',
+      subVibe: '상큼',
+      portfolios: [],
+      menus: [
+        {
+          id: 129,
+          studio: '미에르스튜디오',
+          name: '증명사진',
+          description: '증명사진에 대한 설명입니다.',
+          price: 40000,
+          created_at: null,
+          updated_at: null,
+        },
+        {
+          id: 130,
+          studio: '미에르스튜디오',
+          name: '프로필사진',
+          description: '프로필사진에 대한 설명입니다.',
+          price: 150000,
+          created_at: null,
+          updated_at: null,
+        },
+      ],
+      options: [],
+      created_at: null,
+      updated_at: null,
+      day_of_week: 'THU',
+      bookmark: false,
+    },
+  ],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 20,
+    sort: {
+      empty: true,
+      sorted: false,
+      unsorted: true,
+    },
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  totalPages: 1,
+  totalElements: 2,
+  last: false,
+  size: 20,
+  number: 0,
+  sort: {
+    empty: true,
+    sorted: false,
+    unsorted: true,
+  },
+  numberOfElements: 2,
+  first: true,
+  empty: false,
+};
+
+// fetch 함수 - Mock 처리
+global.fetch = vi.fn();
+
+// useGetStudios를 호출하는 테스트 컴포넌트
+const TestComponent = ({ pageNum, mode, params }: { pageNum: number; mode: 'filter' | 'search/result'; params: string }) => {
+  const { data, isError, isLoading } = useGetStudios(pageNum, mode, params);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (isError) return <div>Error occurred</div>;
+  return <div>{data?.content.map((studio) => <div key={studio.id}>{studio.name}</div>)}</div>;
+};
+
+describe('useGetStudios Hook', () => {
+  const queryClient = new QueryClient();
+  const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+  // 각 테스트 후 Mock 초기화
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('주어진 params를 바탕으로 올바른 API를 호출해야 합니다.', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockedStudios,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent pageNum={0} mode="filter" params="" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${import.meta.env.VITE_TOUCHEESE_API}/studio/filter?size=${import.meta.env.VITE_TOUCHEESE_STUDIO_LIMIT}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+    });
+  });
+
+  test('스튜디오 목록을 성공적으로 fetch해야 합니다.', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockedStudios,
+    });
+
+    const { result } = renderHook(() => useGetStudios(0, 'filter', 'vibeName=시크'), { wrapper });
+
+    // Query가 성공적으로 데이터를 가져올 때까지 대기
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // 결과 확인
+    expect(result.current.data).toEqual(mockedStudios);
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('vibeName=시크'), expect.objectContaining({ method: 'GET' }));
+  });
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -19,6 +19,14 @@ export interface IMenus {
   updated_at: null | string;
 }
 
+export interface IOptions {
+  id: number;
+  name: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface IStudioItem {
   id: number;
   vibe: string;
@@ -39,9 +47,11 @@ export interface IStudioItem {
   subVibe: string;
   portfolios: IPortfolio[];
   menus: IMenus[];
+  options: [] | IOptions;
   created_at: null | string;
   updated_at: null | string;
   day_of_week: 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
+  bookmark: boolean;
 }
 
 export interface IStudioRes {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig, InlineConfig, UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
+
+interface VitestConfigExport extends UserConfig {
+  test: InlineConfig;
+}
 
 export default defineConfig({
   plugins: [react()],
@@ -25,4 +29,4 @@ export default defineConfig({
     globals: true,
     setupFiles: './vitest.setup.ts',
   },
-});
+} as VitestConfigExport);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#75 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `vite.config.ts`의 `test` 부분에서 타입 오류가 발생하여 수정
- Vitest(Jest)의 전역 함수 타입 오류를 방지하기 위해 `devDependencies`에 패키지 설치
- 스튜디오 로딩 시 맨 처음에만 로딩 컴포넌트를 표시하도록 수정
  > **`isLoading` 시에 로딩 컴포넌트를 추가했더니 문제 발생**
  > - 로딩 컴포넌트로 인해 가상화한 요소의 스크롤이 top으로 이동
  > - 로딩 컴포넌트를 `Virtuoso` 안에 두었더니 로딩하는 동안 로딩 컴포넌트가 수없이 반복
  > ⇒ 우선 맨 처음 로딩 시에만 로딩 컴포넌트를 표시하고, 이후 로딩 시에는 Skeleton UI를 사용하는 등의 방법을 고려 중
- 스튜디오 리스트 조회 결과가 없을 시 `EmptyMessage` 추가
- 스튜디오 제공 옵션 타입 추가
- 스튜디오 아이템 북마크 설정 여부 반영 ⇒ **api 나오면 연동 작업 남음**
- 테스트 코드 작성 및 테스트 통과 완료
  - Home 컴포넌트
  - StudioList 컴포넌트
  - StudioItem 컴포넌트
  - useGetStudios 훅

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- @woojoung1217 @HuiseonDev @aksenmi @kyungmim @s0zzang 패키지 설치로 인해 `pnpm i` 한 번 부탁드립니다.
- 목업 데이터 때문에 테스트 코드가 많이 길어요 ,, ,,, ,, ,,ㅎ
- @aksenmi 지민님 EmptyMessage 컴포넌트를 공통으로 사용했고 `isSearchResultEmpy` 함수 대신 조건문을 바로 달았습니다!
  ```
  data?.content.length === 0 ? (
    <EmptyMessage message={`${mode === 'filter' ? '스튜디오 조회' : '검색'} 결과가 없습니다.`} /> ) :
  ...
  ```