### PR TITLE
[S3] 이미지 슬라이드 기능 추가 구현

### DIFF
--- a/src/components/ImageSwiper/ImageSwiper.tsx
+++ b/src/components/ImageSwiper/ImageSwiper.tsx
@@ -2,31 +2,39 @@
 import { css } from '@emotion/react';
 import { Swiper, SwiperSlide, SwiperProps } from 'swiper/react';
 import 'swiper/css';
-import { Mousewheel } from 'swiper/modules';
+import { Autoplay, Mousewheel, Pagination } from 'swiper/modules';
 import variables from '@styles/Variables';
 
 interface ImageSwiperProps extends SwiperProps {
   images: string[];
+  imageStyle?: ReturnType<typeof css>;
 }
 
-const ImageSwiper = ({ images, modules = [Mousewheel], mousewheel = { forceToAxis: true, sensitivity: 1 }, spaceBetween = 3, slidesPerView = 4, ...props }: ImageSwiperProps) => {
+const ImageSwiper = ({
+  images,
+  modules = [Mousewheel, Pagination, Autoplay],
+  mousewheel = { forceToAxis: true, sensitivity: 1 },
+  spaceBetween = 3,
+  slidesPerView = 4,
+  imageStyle,
+  ...props
+}: ImageSwiperProps) => {
+  const isPaginationActive = slidesPerView === 1;
+
   return (
     <Swiper
-      css={css`
-        width: calc(100% + ${variables.layoutPadding});
-        height: 11.8rem;
-        margin-right: ${variables.layoutPadding};
-        margin-bottom: 1.4rem;
-      `}
+      css={swiperStyle}
       modules={modules}
       mousewheel={mousewheel}
       spaceBetween={spaceBetween}
       slidesPerView={slidesPerView}
+      pagination={isPaginationActive ? { clickable: true, type: 'bullets' } : undefined}
+      autoplay={isPaginationActive ? { delay: 3000, disableOnInteraction: false } : undefined}
       {...props}
     >
       {images.map((image, index) => (
         <SwiperSlide key={index}>
-          <img css={imageStyle} src={image} alt={`이미지 ${index + 1}`} />
+          <img css={[defaultImageStyle, imageStyle]} src={image} alt={`이미지 ${index + 1}`} />
         </SwiperSlide>
       ))}
     </Swiper>
@@ -35,8 +43,38 @@ const ImageSwiper = ({ images, modules = [Mousewheel], mousewheel = { forceToAxi
 
 export default ImageSwiper;
 
-const imageStyle = css`
-  width: 9.4rem;
-  height: 11.8rem;
+const swiperStyle = css`
+  width: calc(100% + ${variables.layoutPadding});
+  margin-right: ${variables.layoutPadding};
+  margin-bottom: 1.4rem;
+
+  .swiper-pagination {
+    position: absolute;
+    bottom: 15px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    z-index: 10;
+  }
+
+  .swiper-pagination-bullet {
+    background-color: ${variables.colors.white};
+    opacity: 0.8;
+    width: 20px;
+    height: 3px;
+    transition: all 0.3s ease;
+    margin: 0 1px;
+    cursor: pointer;
+  }
+
+  .swiper-pagination-bullet-active {
+    background-color: ${variables.colors.black};
+    opacity: 1;
+  }
+`;
+
+const defaultImageStyle = css`
+  width: 100%;
+  height: auto;
   object-fit: cover;
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
>  #98


<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 한개용 이미지 슬라이드 방식 구현
- 기존 마우스휠 방식에 페이지네이션, 오토플레이 기능 추가

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

스튜디오 상세에서 쓰이는 이미지는 autoplay이랑 클릭 모두 작동되는 페이지네이션으로 만들어놨습니다. 

스튜디오 상세 페이지에서 slidesPerView={1} 를 설정하고, 적용할 스타일을 추가하시면 됩니다.

예시)

` <ImageSwiper images={['img1.jpg', 'img2.jpg', 'img3.jpg']} slidesPerView={1} imageStyle={custonImageStyle}/>`
