### PR TITLE
[S3] 스튜디오 상세정보 페이지 포트폴리오 미리보기 기능을 구현한다

### DIFF
--- a/src/hooks/useGetStudioDetail.ts
+++ b/src/hooks/useGetStudioDetail.ts
@@ -17,10 +17,12 @@ const fetchStudioDetail = async (studioId: string): Promise<IStudioItem> => {
 
 export const useGetStudioDetail = (studioId: string) => {
   return useQuery<IStudioItem | undefined>({
-    queryKey: ['studioDetail'],
+    queryKey: ['studioDetail', studioId],
     queryFn: () => fetchStudioDetail(studioId),
     staleTime: 1000 * 60 * 60 * 2,
     refetchOnWindowFocus: false,
+    gcTime: 5 * 60 * 1000,
+    enabled: !!studioId,
     // placeholderData: true,
   });
 };

--- a/src/pages/Studio/StudioMain/StudioMain.tsx
+++ b/src/pages/Studio/StudioMain/StudioMain.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource @emotion/react */
-import BackButton from '@components/BackButton/BackButton';
+
+import Header from '@components/Header/Header';
 import StudioNavigator from '@components/Navigator/StudioNavigator';
 import { css } from '@emotion/react';
 import { useGetStudioDetail } from '@hooks/useGetStudioDetail';
-import { TypoBodyMdR, TypoBodyMdSb, TypoCapSmR, TypoTitleMdSb } from '@styles/Common';
+import { DividerStyle, TypoBodyMdR, TypoBodyMdSb, TypoCapSmR, TypoTitleMdSb } from '@styles/Common';
 import variables from '@styles/Variables';
 import { useParams } from 'react-router-dom';
 
@@ -12,6 +13,7 @@ import { useParams } from 'react-router-dom';
 const StudioMain = () => {
   const { _id } = useParams();
   const { data, isLoading, error } = useGetStudioDetail(`${_id}`);
+  console.log(data?.portfolios.map((v) => v));
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -24,18 +26,28 @@ const StudioMain = () => {
   if (!data) {
     return <div>로딩</div>;
   }
+
+  /**이미지 5개 이하일때 대체할 이미지 */
+  const placeHolderImage = '/img/img-nopic.png';
+  const missingImgCount = data.portfolios.length < 5 ? 5 - data.portfolios.length : 0;
+  const portfolioWithPlaceHolders = [...data.portfolios, ...Array(missingImgCount).fill({ url: placeHolderImage })];
+
   return (
     <>
-      <BackButton />
-      {/* 이미지 들어갈자리 */}
-      <div>이미지</div>
+      <Header customStyle={HeaderStyle} />
+      {/* 이미지 */}
+      <div css={portfolioPreviewStyle}>
+        {portfolioWithPlaceHolders.slice(0, 5).map((v, i) => (
+          <img key={i} src={v.url} alt={`Portfolio ${i}`} />
+        ))}
+      </div>
 
       {/* 스튜디오 정보 */}
       <div css={StudioInfoTitleStyle}>
         <div>
           <h2>{`${data.name}`}</h2>
           <div>
-            <img src="/img/icon-star-yellow.svg" alt="리뷰 평점" />
+            <img src="/img/icon-rating.svg" alt="리뷰 평점" />
             <p>{`${data.rating}`}</p>
             <p>{`(${data.review_count}개의 평가)`}</p>
           </div>
@@ -59,7 +71,7 @@ const StudioMain = () => {
           </div>
           <div>
             <dt>
-              <img src="/img/icon-map.svg" alt="주소" />
+              <img src="/img/icon-location.svg" alt="주소" />
             </dt>
             <dd>
               <p>{`${data.address}` === 'undefined' ? '주소 수집중' : `${data.address}`}</p>
@@ -77,6 +89,7 @@ const StudioMain = () => {
       </div>
 
       {/* gray 여백 들어갈 자리 */}
+
       {/* 네비게이션 바 */}
       <StudioNavigator _id={_id || ''} />
       {/* 홈 기본 정보 */}
@@ -90,12 +103,40 @@ const StudioMain = () => {
 
 export default StudioMain;
 
+const HeaderStyle = css`
+  position: absolute;
+  z-index: 1;
+  padding-top: 1.8rem;
+`;
+
+const portfolioPreviewStyle = css`
+  display: grid;
+  gap: 0.2rem;
+  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-rows: repeat(2, 1fr);
+  width: calc(100% + 3.2rem);
+  margin-left: -1.6rem;
+  margin-bottom: 2rem;
+
+  & > img {
+    aspect-ratio: 1/1;
+    object-fit: cover;
+    width: calc(100% - 0.1rem);
+  }
+
+  & > img:first-of-type {
+    grid-column: span 1; /* 첫 번째 이미지는 2개의 열을 차지 */
+    grid-row: span 2; /* 첫 번째 이미지는 2개의 행을 차지 */
+    width: 100%;
+  }
+`;
+
 const StudioInfoTitleStyle = css`
   display: flex;
   justify-content: space-between;
 
   & > div {
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
     & > h2 {
       ${TypoTitleMdSb}
       margin-bottom: 0.4rem;
@@ -103,12 +144,11 @@ const StudioInfoTitleStyle = css`
 
     & > div {
       display: flex;
+      align-items: center;
       & > img {
-        align-items: center;
-        justify-content: center;
         margin-right: 0.4rem;
-        width: 2rem;
-        height: 2rem;
+        width: 1.6rem;
+        height: 1.6rem;
       }
 
       & > p + p {
@@ -120,6 +160,7 @@ const StudioInfoTitleStyle = css`
 `;
 
 const StudioInfoStyle = css`
+  position: relative;
   dl {
     display: flex;
     flex-direction: column;
@@ -132,9 +173,10 @@ const StudioInfoStyle = css`
       dt {
         display: flex;
         margin-right: 1rem;
+
         img {
-          width: 2rem;
-          height: 2rem;
+          width: 1.7rem;
+          height: 1.7rem;
         }
       }
 
@@ -149,6 +191,7 @@ const StudioInfoStyle = css`
         }
       }
     }
+    ${DividerStyle}
   }
 `;
 

--- a/src/styles/Common.tsx
+++ b/src/styles/Common.tsx
@@ -58,6 +58,7 @@ export const TypoCapSmM = css`
 `;
 
 export const DividerStyle = css`
+  padding-bottom: calc(2rem + 1rem);
   &::after {
     content: '';
     position: absolute;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #150 


<br>

## 📝 작업 내용
> 포트폴리오 미리보기 기능 구현
- 공통 컴포넌트 gray 여백 padding 적용
- 이미지 5개 이하라면 대체 이미지 적용
- query key 선언으로 데이터 캐싱, 자동 업데이트 적용
- studio id 가 존재하는 경우만 쿼리 실행

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
