### PR TITLE
[S4] 딤 모달 내 스와이퍼 기능 구현 완료

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -105,6 +105,7 @@ const CloseBtnStyle = styled.button<ICloseBtnStyle>`
   position: absolute;
   left: ${(props) => props.mode === 'fullscreen' && 0};
   right: ${(props) => props.mode === 'dimmed' && 0};
+  z-index: 9;
 `;
 
 const ContentsStyle = styled.div<IContentStyle>`

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -82,7 +82,7 @@ const ModalStyle = styled.section<IModalStyle>`
   position: fixed;
   z-index: 99;
   inset: 0;
-  background: ${(props) => (props.type !== 'fullscreen' ? 'rgba(0,0,0,0.9)' : variables.colors.white)};
+  background: ${(props) => (props.type !== 'fullscreen' ? 'rgba(0,0,0,0.85)' : variables.colors.white)};
   padding: 0 2rem 4.8rem;
   display: flex;
   flex-direction: column;
@@ -90,7 +90,7 @@ const ModalStyle = styled.section<IModalStyle>`
 `;
 
 const TitleStyle = styled.div<ITitleStyle>`
-  padding: ${(props) => (props.type === 'fullscreen' ? '1.4rem 0' : '1.8rem 0')};
+  padding: ${(props) => (props.type === 'fullscreen' ? '1.4rem 0' : '2.8rem 0')};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -111,7 +111,6 @@ const ContentsStyle = styled.div<IContentStyle>`
   padding: ${(props) => props.type === 'fullscreen' && '1rem 0'};
   flex-grow: 1;
   overflow-y: auto;
-  display: ${(props) => props.type === 'dimmed' && 'flex'};
 `;
 
 const ButtonBoxStyle = styled.div`

--- a/src/components/Swiper/DimSwiper.tsx
+++ b/src/components/Swiper/DimSwiper.tsx
@@ -1,5 +1,5 @@
 import { useDimSwiperStore } from '@store/useDimSwiper';
-import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, ReactNode, SetStateAction, useEffect, useLayoutEffect, useState } from 'react';
 import { Navigation, Pagination, Virtual } from 'swiper/modules';
 import { Swiper, SwiperClass } from 'swiper/react';
 import { IPortfolio } from 'types/types';
@@ -13,21 +13,52 @@ interface IDimSwiper {
   setSlideSet: Dispatch<SetStateAction<IPortfolio[]>>;
 }
 
+/*
+1. 첫번째, 마지막 요소에선 handleChange 이벤트 금지
+- 첫번째에선 prev 금지
+- 마지막에선 next 금지
+
+-> 첫번째 마지막 요소인지 어떻게 알지? 
+- data[0].id와 seletedId 비교 : seletedId가 바로 반영되지 않아서 제대로 바뀌지 않음
+- 첫번째, 마지막 요소 : 아이디가 스튜디오마다 아이디가 다르기 때문에 데이터 0번과 비교해야 함
+- 현재 요소 : seletedId (반영 제대로 안됨), 클릭된 그 요소 (상위, 상위 파일에서 작업해야 함)
+- firstSlide : 얘도 클릭한 후에 반영돼서 사용 불가
+
+2. 첫번째 슬라이드 예외 처리 
+- 첫번째 슬라이드를 클릭한 경우 initial Slide 0번째 요소 활성화
+- 첫번째 슬라이드로 이벤트가 발생한 경우 : slideTo 0번째 요소
+
+3. 페이지네이션 
+*/
+
 const DimSwiper = ({ children, data, setSlideSet }: IDimSwiper) => {
   const [swiperRef, setSwiperRef] = useState<SwiperClass>();
   const { selectedId, setSelectedId } = useDimSwiperStore();
-  const isFirstSlide = data[0].id === selectedId;
+  const [firstSlide, setFirstSlide] = useState<number>();
+  const [lastSlide, setLastSlide] = useState<number>();
 
   const getNewSlideSet = (clickedId: number) => {
     return data.filter(({ id }: { id: number }) => id === clickedId || id === clickedId - 1 || id === clickedId + 1);
   };
 
   const handleChange = () => {
-    if (!swiperRef) return null;
+    if (!swiperRef || !firstSlide || !lastSlide) return null;
+    const toNext = swiperRef.swipeDirection === 'next';
+    const direction = toNext ? 1 : -1;
 
-    const direction = swiperRef.swipeDirection === 'next' ? 1 : -1;
+    // 첫번째, 마지막 슬라이드에서 슬라이드 변경 금지
+    if (selectedId === firstSlide) if (!toNext) return;
+    if (selectedId === lastSlide) if (toNext) return;
+
+    // 두번째 슬라이드에서 이전 방향으로 변경된 경우
+    if (selectedId === firstSlide + 1 && !toNext) {
+      setSelectedId(selectedId, direction);
+      swiperRef.slideTo(0, 0, false);
+      return;
+    }
+
     setSelectedId(selectedId, direction);
-    swiperRef.slideTo(isFirstSlide ? 0 : 1, 0, false);
+    swiperRef.slideTo(1, 0, false);
   };
 
   const swiperOption = {
@@ -35,19 +66,23 @@ const DimSwiper = ({ children, data, setSlideSet }: IDimSwiper) => {
     onSwiper: (e: SwiperClass) => setSwiperRef(e),
     onTransitionEnd: handleChange,
     slidesPerView: 1,
-    initialSlide: isFirstSlide ? 0 : 1,
-    pagination: {
-      type: 'fraction' as 'fraction',
-    },
+    initialSlide: selectedId === firstSlide ? 0 : 1,
+    pagination: { type: 'fraction' as 'fraction' },
     centeredSlides: true,
   };
 
   useEffect(() => {
-    // console.log(isFirstSlide);
+    if (data) {
+      setFirstSlide(data[0].id);
+      setLastSlide(data[data.length - 1].id);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
     setSlideSet(getNewSlideSet(selectedId));
   }, [selectedId]);
 
-  return <Swiper {...swiperOption}>{children}</Swiper>;
+  return firstSlide && <Swiper {...swiperOption}>{children}</Swiper>;
 };
 
 export default DimSwiper;

--- a/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
+++ b/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
@@ -13,12 +13,12 @@ const PortfolioSwiper = ({ data, studioName }: { data: IPortfolio[]; studioName:
   return (
     <DimSwiper data={data} setSlideSet={setSlideSet}>
       {slideSet &&
-        slideSet.map(({ id, url, description }) => (
+        slideSet.map(({ id, url, menuName }) => (
           <SwiperSlide key={id} virtualIndex={id}>
             <div css={[SlideImgBox, portfolioSlide]}>
               <img src={url} alt={`${studioName}-${id}`} />
             </div>
-            <p css={TypoBodyMdR}>{description}</p>
+            <p css={TypoBodyMdR}>{menuName}</p>
           </SwiperSlide>
         ))}
     </DimSwiper>

--- a/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
+++ b/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
-import DimSwiper from '@components/Swiper/DimSwiper';
+import DimSwiper, { SlideImgBox } from '@components/Swiper/DimSwiper';
+import { css } from '@emotion/react';
 import { TypoBodyMdR } from '@styles/Common';
 import { useState } from 'react';
 import { SwiperSlide } from 'swiper/react';
@@ -14,7 +15,9 @@ const PortfolioSwiper = ({ data, studioName }: { data: IPortfolio[]; studioName:
       {slideSet &&
         slideSet.map(({ id, url, description }) => (
           <SwiperSlide key={id} virtualIndex={id}>
-            <img src={url} alt={`${studioName}-${id}`} />
+            <div css={[SlideImgBox, portfolioSlide]}>
+              <img src={url} alt={`${studioName}-${id}`} />
+            </div>
             <p css={TypoBodyMdR}>{description}</p>
           </SwiperSlide>
         ))}
@@ -23,3 +26,7 @@ const PortfolioSwiper = ({ data, studioName }: { data: IPortfolio[]; studioName:
 };
 
 export default PortfolioSwiper;
+
+const portfolioSlide = css`
+  margin-top: 4rem;
+`;

--- a/src/pages/Studio/StudioPortfolio/StudioPortfolio.tsx
+++ b/src/pages/Studio/StudioPortfolio/StudioPortfolio.tsx
@@ -40,6 +40,7 @@ const StudioPortfolio = () => {
       const data = await response.json();
       setData(data.portfolioDtos.content);
       setMenuNames(data.menuNameList);
+      setStudioName(data.studioName);
     } catch (err) {
       console.error('Failed to fetch data');
     }
@@ -47,7 +48,6 @@ const StudioPortfolio = () => {
 
   useEffect(() => {
     fetchPortfolio();
-    if (data.length) setStudioName(data[0].studio);
   }, []);
 
   return (

--- a/src/pages/Studio/components/DimmedModal.tsx
+++ b/src/pages/Studio/components/DimmedModal.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import Modal from '@components/Modal/Modal';
-// import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 const DimmedModal = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
-      <Modal type="dimmed" title={`3/20`} withBtn={false}>
+      <Modal type="dimmed" withBtn={false}>
         <DimmedModalStyle>{children}</DimmedModalStyle>
       </Modal>
     </>
@@ -14,12 +13,9 @@ const DimmedModal = ({ children }: { children: React.ReactNode }) => {
 };
 
 const DimmedModalStyle = styled.div`
-  width: 100%;
-  display: flex;
+  * {
+    color: #fff;
+  }
 `;
-
-// const swiperStyle = css`
-//   color: white;
-// `;
 
 export default DimmedModal;

--- a/src/store/useDimSwiper.ts
+++ b/src/store/useDimSwiper.ts
@@ -7,5 +7,5 @@ interface DimSwiperState {
 
 export const useDimSwiperStore = create<DimSwiperState>((set) => ({
   selectedId: 0,
-  setSelectedId: (id, direction) => set((state) => ({ selectedId: (id || state.selectedId) + (direction || 1) })),
+  setSelectedId: (id, direction) => set(() => ({ selectedId: id + (direction || 0) })),
 }));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,6 +7,7 @@ export interface IPortfolio {
   name: string;
   url: string;
   menuId: number;
+  menuName: string;
   description: string;
   created_at: string;
   updated_at: null | string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #191 


<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 딤 모달 내 스와이퍼 기능 구현
- 딤 모달 스타일 변경 
- 포트폴리오 딤 모달 내 노출되는 데이터 변경 : 설명 -> 메뉴명
- 모달 닫기 버튼 z-index 변경

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

![Jan-01-2025 16-22-25](https://github.com/user-attachments/assets/6c318ffb-8ec9-4203-9589-cad8cabce1c6)
⬆️ 최대 3개만 담긴 스와이퍼 예시

- 포트폴리오 아이템을 클릭하면 딤 모달이 열리고 클릭한 아이템의 앞, 뒤를 포함한 최대 3개의 아이템만 스와이퍼에 담깁니다. 
- 스와이퍼가 3개씩 담기기 때문에 스와이퍼 페이지네이션을 사용할 수 없었습니다. 
따라서 현재 인덱스와 데이터 총 개수를 구하여 페이지네이션을 구현하였습니다.
- 포트폴리오 목록 데이터를 무한 스크롤 하는 경우는 반영되지 않았습니다. (ㅠ)
- 난이도가 있었던만큼 상세한 코드 리뷰 부탁드립니다 !