### PR TITLE
[S4] 리뷰 모아보기 페이지에 딤 모달 스와이퍼 적용

### DIFF
--- a/src/components/Swiper/DimSwiper.tsx
+++ b/src/components/Swiper/DimSwiper.tsx
@@ -1,31 +1,40 @@
 /** @jsxImportSource @emotion/react */
 
 import { useDimSwiperStore } from '@store/useDimSwiper';
-import { Dispatch, ReactNode, SetStateAction, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { Navigation, Virtual } from 'swiper/modules';
 import { Swiper, SwiperClass } from 'swiper/react';
-import { IPortfolio } from 'types/types';
 
-import 'swiper/css';
-import { TypoBodyMdR } from '@styles/Common';
 import { css } from '@emotion/react';
+import { TypoBodyMdR } from '@styles/Common';
+import 'swiper/css';
 
-interface IDimSwiper {
+interface IDimSwiper<T extends { id: number }> {
   children: ReactNode;
-  data: IPortfolio[];
-  setSlideSet: Dispatch<SetStateAction<IPortfolio[]>>;
+  data: T[];
+  setSlideSet: Dispatch<SetStateAction<T[]>>;
 }
 
-const DimSwiper = ({ children, data, setSlideSet }: IDimSwiper) => {
+const DimSwiper = <T extends { id: number }>({ children, data, setSlideSet }: IDimSwiper<T>) => {
   const { selectedId, setSelectedId } = useDimSwiperStore();
   const [swiperRef, setSwiperRef] = useState<SwiperClass>();
   const [firstSlide, setFirstSlide] = useState<number>();
   const [lastSlide, setLastSlide] = useState<number>();
-  const [activeIndex, setActiveIndex] = useState<number>(0);
+  const [activeIndex, setActiveIndex] = useState<number>(1);
   const slideIndexMap = useMemo(() => new Map(), []);
 
   const getNewSlideSet = (clickedId: number) => {
-    return data.filter(({ id }: { id: number }) => id === clickedId || id === clickedId - 1 || id === clickedId + 1);
+    return data.filter(
+      ({ id }: { id: number }) => id === clickedId || id === clickedId - 1 || id === clickedId + 1,
+    );
   };
 
   const setIndexByPortfolioId = () => {

--- a/src/components/Swiper/DimSwiper.tsx
+++ b/src/components/Swiper/DimSwiper.tsx
@@ -1,15 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { useDimSwiperStore } from '@store/useDimSwiper';
-import {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { Navigation, Virtual } from 'swiper/modules';
 import { Swiper, SwiperClass } from 'swiper/react';
 
@@ -81,7 +73,7 @@ const DimSwiper = <T extends { id: number }>({ children, data, setSlideSet }: ID
     }
   }, []);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setSlideSet(getNewSlideSet(selectedId));
     setActiveIndex(slideIndexMap.get(selectedId));
   }, [selectedId]);

--- a/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
+++ b/src/pages/Studio/StudioPortfolio/PortfolioSwiper.tsx
@@ -11,7 +11,7 @@ const PortfolioSwiper = ({ data, studioName }: { data: IPortfolio[]; studioName:
   const [slideSet, setSlideSet] = useState<IPortfolio[]>([]);
 
   return (
-    <DimSwiper data={data} setSlideSet={setSlideSet}>
+    <DimSwiper<IPortfolio> data={data} setSlideSet={setSlideSet}>
       {slideSet &&
         slideSet.map(({ id, url, menuName }) => (
           <SwiperSlide key={id} virtualIndex={id}>

--- a/src/pages/Studio/StudioReview/StudioReviewPhotos.tsx
+++ b/src/pages/Studio/StudioReview/StudioReviewPhotos.tsx
@@ -3,14 +3,15 @@ import Button from '@components/Button/Button';
 import Header from '@components/Header/Header';
 import MasonryList from '@components/Masonry/Masonry';
 import styled from '@emotion/styled';
+import useModal from '@hooks/useModal';
+import DimmedModal from '@pages/Studio/components/DimmedModal';
+import { useDimSwiperStore } from '@store/useDimSwiper';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { IReviewImages } from 'types/types';
-import DimmedModal from '@pages/Studio/components/DimmedModal';
-import { SwiperSlide } from 'swiper/react';
-import useModal from '@hooks/useModal';
-import { Helmet } from 'react-helmet-async';
+import ReviewSwiper from './components/ReviewSwiper';
 
 interface IReviewImagesResponse {
   totalElements: number;
@@ -24,6 +25,12 @@ const StudioReviewPhotos = () => {
   const { _id } = useParams(); // 스튜디오 아이디
   const [selectedMenuId, setSelectedMenuId] = useState<number | null>(null);
   const [_, setSearchParams] = useSearchParams();
+
+  const setSelectedId = useDimSwiperStore((state) => state.setSelectedId);
+  const handleClick = (clickedId: number) => {
+    setSelectedId(clickedId);
+    open();
+  };
 
   const { open } = useModal(1);
   const fetchReviewImage = async () => {
@@ -73,7 +80,14 @@ const StudioReviewPhotos = () => {
       <Header title="리뷰 사진 모아보기" />
       <StudioReviewPhotosContainerStyle>
         <ButtonWrapperStyle>
-          <Button text="전체" variant="white" active={selectedMenuId === null} size="small" width="fit" onClick={() => setSelectedMenuId(null)} />
+          <Button
+            text="전체"
+            variant="white"
+            active={selectedMenuId === null}
+            size="small"
+            width="fit"
+            onClick={() => setSelectedMenuId(null)}
+          />
           {reviewImages.menuNameList.map((menu, index) => (
             <Button
               key={menu}
@@ -89,18 +103,14 @@ const StudioReviewPhotos = () => {
 
         <MasonryList>
           {reviewImages.imageDtos.map(({ id, url }) => (
-            <div key={id} onClick={() => open()}>
+            <div key={id} onClick={() => handleClick(id)}>
               <img src={url} alt={`리뷰 이미지 ${id}`} />
             </div>
           ))}
         </MasonryList>
 
         <DimmedModal>
-          {reviewImages.imageDtos.map(({ id, url }) => (
-            <SwiperSlide key={id}>
-              <img src={url} alt={`리뷰 이미지 ${id}`} />
-            </SwiperSlide>
-          ))}
+          <ReviewSwiper data={reviewImages.imageDtos} />
         </DimmedModal>
       </StudioReviewPhotosContainerStyle>
     </>

--- a/src/pages/Studio/StudioReview/components/ReviewSwiper.tsx
+++ b/src/pages/Studio/StudioReview/components/ReviewSwiper.tsx
@@ -1,0 +1,26 @@
+/** @jsxImportSource @emotion/react */
+
+import DimSwiper, { SlideImgBox } from '@components/Swiper/DimSwiper';
+import { useState } from 'react';
+import { SwiperSlide } from 'swiper/react';
+import { IReviewImages } from 'types/types';
+
+const ReviewSwiper = ({ data }: { data: IReviewImages[] }) => {
+  const [slideSet, setSlideSet] = useState<IReviewImages[]>([]);
+
+  return (
+    <DimSwiper<IReviewImages> data={data} setSlideSet={setSlideSet}>
+      {slideSet &&
+        slideSet.map(({ id, url }) => (
+          <SwiperSlide key={id} virtualIndex={id}>
+            <div css={[SlideImgBox]}>
+              <img src={url} alt={`리뷰 이미지 ${id}`} />
+            </div>
+            <p>기타 내용 작성</p>
+          </SwiperSlide>
+        ))}
+    </DimSwiper>
+  );
+};
+
+export default ReviewSwiper;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #267 


<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 리뷰 모아보기 페이지에 딤 모달 스와이퍼 적용 완료
- 딤 모달 스와이퍼에서 사용하는 데이터 타입을 제네릭으로 변경
- 배포 버전에서 딤 스와이퍼 활성화 인덱스 미노출 오류 개선 (배포 확인해봐야 함)

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@woojoung1217 님, 리뷰 모아보기 페이지에 딤 스와이퍼 적용 완료했습니다.
현재 이미지만 노출되는 상태이니 모달 내부 작업 부탁드립니다.
