### PR TITLE
[S5] 예약 내역 조회 기능 추가

### DIFF
--- a/src/components/Navigator/ReservationNavigator.tsx
+++ b/src/components/Navigator/ReservationNavigator.tsx
@@ -5,21 +5,25 @@ import { TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
 import { Dispatch, SetStateAction } from 'react';
 
+const STATUS: ResStatus[] = [
+  { statusKor: '이용 예정', statusEng: 'DEFAULT' },
+  { statusKor: '이용 완료', statusEng: 'COMPLETED' },
+  { statusKor: '예약 취소', statusEng: 'CANCELED' },
+];
+
 const ReservationNavigator = ({
-  list,
   status,
   setStatus,
 }: {
-  list: ResStatus[];
   status: ResStatus;
   setStatus: Dispatch<SetStateAction<ResStatus>>;
 }) => {
   return (
     <nav>
       <UlStyle>
-        {list.map((item, index) => {
-          const isActive = item === status;
-          const length = list.length;
+        {STATUS.map((item, index) => {
+          const isActive = item.statusKor === status.statusKor;
+          const length = STATUS.length;
 
           return (
             <LiStyle
@@ -28,7 +32,7 @@ const ReservationNavigator = ({
               onClick={() => setStatus(item)}
               length={length}
             >
-              <span css={TypoTitleXsM}>{item}</span>
+              <span css={TypoTitleXsM}>{item.statusKor}</span>
             </LiStyle>
           );
         })}

--- a/src/components/Navigator/ReservationNavigator.tsx
+++ b/src/components/Navigator/ReservationNavigator.tsx
@@ -7,8 +7,8 @@ import { Dispatch, SetStateAction } from 'react';
 
 const STATUS: ResStatus[] = [
   { statusKor: '이용 예정', statusEng: 'DEFAULT' },
-  { statusKor: '이용 완료', statusEng: 'COMPLETED' },
-  { statusKor: '예약 취소', statusEng: 'CANCELED' },
+  { statusKor: '이용 완료', statusEng: 'COMPLETE' },
+  { statusKor: '예약 취소', statusEng: 'CANCEL' },
 ];
 
 const ReservationNavigator = ({

--- a/src/hooks/useGetReservationList.ts
+++ b/src/hooks/useGetReservationList.ts
@@ -1,18 +1,73 @@
-import { ResStatus } from '@pages/Reservation/ReservationList';
-import { useQuery } from '@tanstack/react-query';
+import { defaultUserState } from '@store/useUserStore';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { getLocalStorageItem } from '@utils/getLocalStorageItem';
+import { IResvItem, IResvRes, IUser } from 'types/types';
+
+export type ResStatus = 'DEFAULT' | 'RESERVED' | 'COMPLETED' | 'CANCELED';
 
 // 예약 상태 별 예약 내역을 불러오는 hook
-// api 완성되면 연동
-const fetchReservationList = async (resStatus: ResStatus, accessToken: string) => {
-  console.log(accessToken);
+const fetchReservationList = async (status: ResStatus): Promise<IResvRes> => {
+  const { accessToken } = getLocalStorageItem<IUser>('userState', defaultUserState);
+  const newStatus = status.toLowerCase();
 
-  const response = await fetch(`${import.meta.env.VITE_TOUCHEESE_API}/${resStatus}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      // Authorization: Bearer ${accessToken}
+  // 이용 완료, 예약 취소 --> 임시 데이터
+  const reserved: IResvItem[] = [
+    {
+      reservationId: 11,
+      studioId: 146,
+      studioName: '주 스튜디오',
+      menuId: 71,
+      menuName: '증명사진',
+      date: '2025-01-09',
+      startTime: '12:00:00',
+      menuImgUrl: 'https://placehold.co/600x400',
+      status: 'RESERVED',
     },
-  });
+  ];
+  const completed: IResvItem[] = [
+    {
+      reservationId: 8,
+      studioId: 146,
+      studioName: '주 스튜디오',
+      menuId: 71,
+      menuName: '증명사진',
+      date: '2023-12-01',
+      startTime: '14:00:00',
+      menuImgUrl: 'https://placehold.co/600x400',
+      status: 'COMPLETED',
+      review: {
+        rating: 4,
+        content: '좋았어요',
+      },
+    },
+    {
+      reservationId: 10,
+      studioId: 146,
+      studioName: '주 스튜디오',
+      menuId: 71,
+      menuName: '증명사진',
+      date: '2023-12-01',
+      startTime: '14:00:00',
+      menuImgUrl: 'https://placehold.co/600x400',
+      status: 'COMPLETED',
+    },
+  ];
+  const canceled: IResvItem[] = [];
+
+  if (newStatus === 'reserved') return reserved;
+  else if (newStatus === 'completed') return completed;
+  else if (newStatus === 'canceled') return canceled;
+
+  const response = await fetch(
+    `${import.meta.env.VITE_TOUCHEESE_API}/user/mypage/reservation${newStatus !== 'default' ? `/${newStatus}` : ''}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
 
   if (!response.ok) {
     console.error('Failed to fetch data');
@@ -21,11 +76,12 @@ const fetchReservationList = async (resStatus: ResStatus, accessToken: string) =
   return response.json();
 };
 
-export const useGetReservationList = (resStatus: ResStatus, accessToken: string) => {
+export const useGetReservationList = (resStatus: ResStatus): UseQueryResult<IResvRes> => {
   return useQuery({
-    queryKey: [resStatus],
-    queryFn: () => fetchReservationList(resStatus, accessToken),
+    queryKey: ['reservation', { resStatus }],
+    queryFn: () => fetchReservationList(resStatus),
     staleTime: 1000 * 60 * 1,
     refetchOnWindowFocus: false,
+    retry: 3,
   });
 };

--- a/src/hooks/useGetReservationList.ts
+++ b/src/hooks/useGetReservationList.ts
@@ -1,62 +1,14 @@
 import { defaultUserState } from '@store/useUserStore';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { getLocalStorageItem } from '@utils/getLocalStorageItem';
-import { IResvItem, IResvRes, IUser } from 'types/types';
+import { IResvRes, IUser } from 'types/types';
 
-export type ResStatus = 'DEFAULT' | 'RESERVED' | 'COMPLETED' | 'CANCELED';
+export type ResStatus = 'DEFAULT' | 'RESERVED' | 'COMPLETE' | 'CANCEL';
 
 // 예약 상태 별 예약 내역을 불러오는 hook
 const fetchReservationList = async (status: ResStatus): Promise<IResvRes> => {
   const { accessToken } = getLocalStorageItem<IUser>('userState', defaultUserState);
   const newStatus = status.toLowerCase();
-
-  // 이용 완료, 예약 취소 --> 임시 데이터
-  const reserved: IResvItem[] = [
-    {
-      reservationId: 11,
-      studioId: 146,
-      studioName: '주 스튜디오',
-      menuId: 71,
-      menuName: '증명사진',
-      date: '2025-01-09',
-      startTime: '12:00:00',
-      menuImgUrl: 'https://placehold.co/600x400',
-      status: 'RESERVED',
-    },
-  ];
-  const completed: IResvItem[] = [
-    {
-      reservationId: 8,
-      studioId: 146,
-      studioName: '주 스튜디오',
-      menuId: 71,
-      menuName: '증명사진',
-      date: '2023-12-01',
-      startTime: '14:00:00',
-      menuImgUrl: 'https://placehold.co/600x400',
-      status: 'COMPLETED',
-      review: {
-        rating: 4,
-        content: '좋았어요',
-      },
-    },
-    {
-      reservationId: 10,
-      studioId: 146,
-      studioName: '주 스튜디오',
-      menuId: 71,
-      menuName: '증명사진',
-      date: '2023-12-01',
-      startTime: '14:00:00',
-      menuImgUrl: 'https://placehold.co/600x400',
-      status: 'COMPLETED',
-    },
-  ];
-  const canceled: IResvItem[] = [];
-
-  if (newStatus === 'reserved') return reserved;
-  else if (newStatus === 'completed') return completed;
-  else if (newStatus === 'canceled') return canceled;
 
   const response = await fetch(
     `${import.meta.env.VITE_TOUCHEESE_API}/user/mypage/reservation${newStatus !== 'default' ? `/${newStatus}` : ''}`,

--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -4,98 +4,41 @@ import ReservationNavigator from '@components/Navigator/ReservationNavigator';
 import ReservationCard from '@components/ReservationCard/ReservationCard';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useGetReservationList } from '@hooks/useGetReservationList';
 import { TypoBodyMdM, TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
 import { useEffect, useState } from 'react';
+import { IResvItem } from 'types/types';
 
-export type ResStatus = '이용 예정' | '이용 완료' | '예약 취소';
-const STATUS: ResStatus[] = ['이용 예정', '이용 완료', '예약 취소'];
-
-export interface IResItem {
-  id: number;
-  status: 'pending' | 'confirmed' | 'completed' | 'canceled';
-  studio: string;
-  menu: string;
-  menuImage: string;
-  date: string;
-  time: string;
-  review?: {
-    rating: number;
-    content: string;
-  };
+export interface ResStatus {
+  statusKor: '이용 예정' | '이용 완료' | '예약 취소';
+  statusEng: 'DEFAULT' | 'COMPLETED' | 'CANCELED';
 }
 
-// 임시 데이터
-const reserved: IResItem[] = [
-  {
-    id: 2,
-    status: 'confirmed',
-    studio: '모노 멘션',
-    menu: '상반신 촬영',
-    menuImage: 'https://i.imgur.com/7C4GSF4.webp',
-    date: '2025-01-25',
-    time: '13:00',
-  },
-  {
-    id: 1,
-    status: 'pending',
-    studio: '모노 멘션',
-    menu: '상반신 촬영',
-    menuImage: 'https://i.imgur.com/7C4GSF4.webp',
-    date: '2025-01-18',
-    time: '13:00',
-  },
-];
-
-const completed: IResItem[] = [
-  {
-    id: 4,
-    status: 'completed',
-    studio: '모노 멘션',
-    menu: '상반신 촬영',
-    menuImage: 'https://i.imgur.com/7C4GSF4.webp',
-    date: '2025-01-25',
-    time: '13:00',
-    review: {
-      rating: 4,
-      content: '좋았어요',
-    },
-  },
-  {
-    id: 3,
-    status: 'completed',
-    studio: '모노 멘션',
-    menu: '상반신 촬영',
-    menuImage: 'https://i.imgur.com/7C4GSF4.webp',
-    date: '2025-01-12',
-    time: '13:00',
-  },
-];
-
-const canceled: IResItem[] = [];
-
 const ReservationList = () => {
-  const [resStatus, setResStatus] = useState<ResStatus>('이용 예정');
-  const [data, setData] = useState<IResItem[]>([]);
-
-  // 로컬 스토리지에서 토큰 꺼내기
-  // const { accessToken } = getLocalStorageItem<IUser>('userState', defaultUserState);
+  const [resStatus, setResStatus] = useState<ResStatus>({
+    statusKor: '이용 예정',
+    statusEng: 'DEFAULT',
+  });
+  const [items, setItems] = useState<IResvItem[]>([]);
 
   // resStatus 변경 시 api 호출
-  useEffect(() => {
-    // if (accessToken) {
-    //   const result = useGetReservationList(resStatus, accessToken);
-    // }
+  const { data } = useGetReservationList(resStatus.statusEng);
 
-    // 임시로 데이터 set
-    if (resStatus === '이용 예정') setData(reserved);
-    else if (resStatus === '이용 완료') setData(completed);
-    else setData(canceled);
-  }, [resStatus]);
+  // resStatus 변경 시 아이템 초기화
+  useEffect(() => {
+    setItems([]);
+  }, [resStatus.statusEng]);
+
+  useEffect(() => {
+    if (data) {
+      setItems(data);
+    }
+  }, [data]);
 
   // 예약 내역이 없을 시 메시지 생성
   let emptyMessage;
-  switch (resStatus) {
+  switch (resStatus.statusKor) {
     case '이용 예정':
       emptyMessage = (
         <p css={TypoTitleXsM}>
@@ -119,15 +62,15 @@ const ReservationList = () => {
     <>
       <HeaderContainerStyle>
         <Header title="예약내역" backTo="/user/mypage" customStyle={headerStyle} />
-        <ReservationNavigator list={STATUS} status={resStatus} setStatus={setResStatus} />
+        <ReservationNavigator status={resStatus} setStatus={setResStatus} />
       </HeaderContainerStyle>
 
-      <SectionStyle className={data.length ? '' : 'empty'}>
-        {data.length ? (
+      <SectionStyle className={items.length ? '' : 'empty'}>
+        {items.length ? (
           <ContentStyle>
-            <p css={TypoBodyMdM}>총 {data.length}건</p>
-            {data.map((item) => (
-              <ReservationCard key={item.id} data={item} />
+            <p css={TypoBodyMdM}>총 {items.length}건</p>
+            {items.map((item) => (
+              <ReservationCard key={item.reservationId} data={item} />
             ))}
           </ContentStyle>
         ) : (

--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -12,7 +12,7 @@ import { IResvItem } from 'types/types';
 
 export interface ResStatus {
   statusKor: '이용 예정' | '이용 완료' | '예약 취소';
-  statusEng: 'DEFAULT' | 'COMPLETED' | 'CANCELED';
+  statusEng: 'DEFAULT' | 'COMPLETE' | 'CANCEL';
 }
 
 const ReservationList = () => {
@@ -24,6 +24,7 @@ const ReservationList = () => {
 
   // resStatus 변경 시 api 호출
   const { data } = useGetReservationList(resStatus.statusEng);
+  console.log(data);
 
   // resStatus 변경 시 아이템 초기화
   useEffect(() => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -184,3 +184,22 @@ export interface IUserRes {
   user_id: number;
   username: string;
 }
+
+export type IResvRes = IResvItem[];
+
+export interface IResvItem {
+  reservationId: number;
+  studioId: number;
+  studioName: string;
+  menuId: number;
+  menuName: string;
+  menuImgUrl: string;
+  status: 'WAITING' | 'RESERVED' | 'COMPLETED' | 'CANCELED';
+  date: string;
+  startTime: string;
+  // 임시
+  review?: {
+    rating: number;
+    content: string;
+  };
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -194,7 +194,7 @@ export interface IResvItem {
   menuId: number;
   menuName: string;
   menuImgUrl: string;
-  status: 'WAITING' | 'RESERVED' | 'COMPLETED' | 'CANCELED';
+  status: 'WAITING' | 'RESERVED' | 'COMPLETE' | 'CANCEL';
   date: string;
   startTime: string;
   // 임시


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#306

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 예약 내역 조회 api의 response에 대한 타입 추가
  - `IResvRes`
- 예약 내역 조회 결과에 대한 타입 추가
  - `IResvItem`
- 예약 내역 조회 공통 useQuery 훅 수정

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
