### PR TITLE
[QA2] 페이지 이동 시 스크롤 최상단으로 이동하지 않는 버그 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,14 @@
+import ErrorBoundary from '@components/Error/ErrorBoundary.tsx';
+import Loading from '@components/Loading/Loading.tsx';
+import Toast from '@components/Toast/Toast.tsx';
 import { Global, ThemeProvider } from '@emotion/react';
 import GlobalStyles from '@styles/GlobalStyles';
 import variables from '@styles/Variables';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, RouterProvider } from 'react-router-dom';
-import router from './routes.tsx';
-import { HelmetProvider } from 'react-helmet-async';
-import ErrorBoundary from '@components/Error/ErrorBoundary.tsx';
 import { Suspense, useDeferredValue, useEffect, useState } from 'react';
-import Toast from '@components/Toast/Toast.tsx';
-import Loading from '@components/Loading/Loading.tsx';
-import ScrollToTop from '@hooks/useScrollToTop.ts';
+import { HelmetProvider } from 'react-helmet-async';
+import { RouterProvider } from 'react-router-dom';
+import router from './routes.tsx';
 
 const queryClient = new QueryClient();
 
@@ -32,12 +31,7 @@ function App() {
               {!deferredReady ? (
                 <Loading size="big" phrase="세상의 모든 사진관, 터치즈" />
               ) : (
-                <>
-                  <BrowserRouter>
-                    <ScrollToTop />
-                  </BrowserRouter>
-                  <RouterProvider router={router} />
-                </>
+                <RouterProvider router={router} />
               )}
               <Toast />
             </Suspense>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,13 @@
+import ScrollToTop from '@hooks/useScrollToTop';
 import { Outlet } from 'react-router-dom';
 
 const Layout = () => {
-  return <Outlet />;
+  return (
+    <>
+      <ScrollToTop />
+      <Outlet />
+    </>
+  );
 };
 
 export default Layout;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,3 +1,4 @@
+import Layout from '@components/Layout/Layout';
 import ReservationNpayCallback from '@pages/Reservation/ReservationNpayCallback';
 import StudioReviewWritePage from '@pages/Studio/StudioReview/StudioReviewWritePage';
 import Auth from '@pages/User/Auth';
@@ -36,135 +37,141 @@ const ReservationCanceled = lazy(() => import('@pages/Reservation/ReservationCan
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <Home />,
-  },
-  {
-    path: 'user',
+    element: <Layout />,
     children: [
       {
-        path: 'auth',
-        element: <Auth />,
+        path: '/',
+        element: <Home />,
       },
       {
-        path: 'auth/kakao/callback',
-        element: <KakaoCallback />,
-      },
-      {
-        path: 'AuthVerification',
-        element: <AuthVerification />,
-      },
-
-      {
-        path: 'signup',
-        element: <SignUp />,
-      },
-
-      {
-        path: 'signupSuccess',
-        element: <SignupSuccess />,
-      },
-
-      {
-        path: 'mypage',
-        element: <MyPage />,
-      },
-      {
-        path: 'profile',
-        element: <Profile />,
-      },
-      {
-        path: 'profile/edit',
-        element: <ChangeProfile />,
-      },
-      {
-        path: 'profile/passwordConfirm',
-        element: <PasswordConfirm />,
-      },
-      {
-        path: 'profile/passwordChange',
-        element: <ChangePassword />,
-      },
-      {
-        path: 'myReviews',
-        element: <MyReviews />,
-      },
-      {
-        path: 'bookmarks',
-        element: <BookmarkedStudios />,
-      },
-    ],
-  },
-  {
-    path: '/login',
-    element: <LoginWithEmailPage />,
-  },
-  {
-    path: 'search',
-    element: <Search />,
-  },
-  {
-    path: 'search/results',
-    element: <SearchResults />,
-  },
-  {
-    path: 'studio/:_id',
-    children: [
-      { index: true, element: <StudioMain /> },
-      {
-        path: 'menu',
-        children: [
-          { index: true, element: <StudioMenu /> },
-          { path: ':_menuId', element: <StudioMenuDetail /> },
-        ],
-      },
-      { path: 'portfolio', element: <StudioPortfolio /> },
-      {
-        path: 'review',
+        path: 'user',
         children: [
           {
-            index: true,
-            element: <StudioReview />,
+            path: 'auth',
+            element: <Auth />,
           },
-          { path: 'photos', element: <StudioReviewPhotos /> },
+          {
+            path: 'auth/kakao/callback',
+            element: <KakaoCallback />,
+          },
+          {
+            path: 'AuthVerification',
+            element: <AuthVerification />,
+          },
+
+          {
+            path: 'signup',
+            element: <SignUp />,
+          },
+
+          {
+            path: 'signupSuccess',
+            element: <SignupSuccess />,
+          },
+
+          {
+            path: 'mypage',
+            element: <MyPage />,
+          },
+          {
+            path: 'profile',
+            element: <Profile />,
+          },
+          {
+            path: 'profile/edit',
+            element: <ChangeProfile />,
+          },
+          {
+            path: 'profile/passwordConfirm',
+            element: <PasswordConfirm />,
+          },
+          {
+            path: 'profile/passwordChange',
+            element: <ChangePassword />,
+          },
+          {
+            path: 'myReviews',
+            element: <MyReviews />,
+          },
+          {
+            path: 'bookmarks',
+            element: <BookmarkedStudios />,
+          },
         ],
       },
+      {
+        path: '/login',
+        element: <LoginWithEmailPage />,
+      },
+      {
+        path: 'search',
+        element: <Search />,
+      },
+      {
+        path: 'search/results',
+        element: <SearchResults />,
+      },
+      {
+        path: 'studio/:_id',
+        children: [
+          { index: true, element: <StudioMain /> },
+          {
+            path: 'menu',
+            children: [
+              { index: true, element: <StudioMenu /> },
+              { path: ':_menuId', element: <StudioMenuDetail /> },
+            ],
+          },
+          { path: 'portfolio', element: <StudioPortfolio /> },
+          {
+            path: 'review',
+            children: [
+              {
+                index: true,
+                element: <StudioReview />,
+              },
+              { path: 'photos', element: <StudioReviewPhotos /> },
+            ],
+          },
 
+          {
+            path: 'reservation',
+            children: [
+              {
+                index: true,
+                element: <ReservationSchedule />,
+              },
+              {
+                path: 'payment',
+                element: <ReservationCheck />,
+              },
+              {
+                path: 'complete',
+                element: <ReservationComplete />,
+              },
+              { path: 'npay/callback', element: <ReservationNpayCallback /> },
+            ],
+          },
+        ],
+      },
       {
         path: 'reservation',
         children: [
           {
-            index: true,
-            element: <ReservationSchedule />,
+            path: 'list',
+            element: <ReservationList />,
           },
           {
-            path: 'payment',
-            element: <ReservationCheck />,
+            path: ':_id',
+            children: [
+              { index: true, element: <ReservationDetail /> },
+              { path: 'canceled', element: <ReservationCanceled /> },
+              { path: 'review/write', element: <StudioReviewWritePage /> },
+            ],
           },
-          {
-            path: 'complete',
-            element: <ReservationComplete />,
-          },
-          { path: 'npay/callback', element: <ReservationNpayCallback /> },
+          {},
         ],
       },
-    ],
-  },
-  {
-    path: 'reservation',
-    children: [
-      {
-        path: 'list',
-        element: <ReservationList />,
-      },
-      {
-        path: ':_id',
-        children: [
-          { index: true, element: <ReservationDetail /> },
-          { path: 'canceled', element: <ReservationCanceled /> },
-          { path: 'review/write', element: <StudioReviewWritePage /> },
-        ],
-      },
-      {},
     ],
   },
 ]);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#420 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- `route.tsx` 구조 변경 - 기존 라우팅 경로들을 `children` 하위로 이동
  <img width="502" alt="image" src="https://github.com/user-attachments/assets/90205eba-9401-448f-867d-83db6eb0fde4" />

- `ScrollToTop` 훅 호출 위치 변경`Layout` 컴포넌트 내부에서 `ScrollToTop` 훅 호출

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

### `route.tsx` 파일이 변경되었으니 꼭! pull 받고 사용해주세요.

#### `ScrollToTop`을 이용해 url 변경 시 스크롤을 최상단으로 이동시킵니다.
- 소정님이 만드신 `useScrollToTop` 훅을 사용하였습니다. ([PR 참고](https://github.com/TEAM-FLASH/Toucheese-FE/pull/399/files))
- 기존에는 `RouteProvider` 외부에 `ScrollToTop` 훅을 배치하였습니다.
  ```tsx
    <>
      <BrowserRouter>
        <ScrollToTop />
      </BrowserRouter>
      <RouterProvider router={router} />
    </>
  ```
- `useLocation`이 `RouteProvider` 내부에 위치하지 않아 url 변경을 감지하지 못하는 문제가 있었습니다.
- 따라서`Layout` 컴포넌트 내부에서 `ScrollToTop` 훅을 호출하여 `RouteProvider` 내부에서 호출할 수 있도록 변경하였습니다.
  ```tsx
  import ScrollToTop from '@hooks/useScrollToTop';
  import { Outlet } from 'react-router-dom';
  
  const Layout = () => {
    return (
      <>
        <ScrollToTop />
        <Outlet />
      </>
    );
  };
  
  export default Layout;
  ```

- 이를 위해 `route.tsx`에서 루트 경로의 `element`를 `Layout` 컴포넌트로 변경하고, 하위 `children`에 기존 라우팅 객체들을 배치하는 방식으로 변경하였습니다.