### PR TITLE
[Q2] 이미지 슬라이드 양쪽 여백 추가

### DIFF
--- a/src/components/Swiper/ImageSwiper.tsx
+++ b/src/components/Swiper/ImageSwiper.tsx
@@ -41,7 +41,7 @@ const ImageSwiper = ({
   };
 
   const conditionalContainerStyle =
-    slidesPerView === 1 ? containerFullStyle : containerDefaultStyle(isSwiped);
+    slidesPerView === 1 ? containerFullStyle : containerDefaultStyle;
 
   return (
     <div css={conditionalContainerStyle}>
@@ -79,10 +79,27 @@ const containerFullStyle = css`
 `;
 
 //다중이미지
-const containerDefaultStyle = (isSwiped: boolean) => css`
-  width: 100%;
+const containerDefaultStyle = css`
   margin-bottom: 1.4rem;
-  margin-left: ${isSwiped ? `calc(-1 * ${variables.layoutPadding})` : '0'};
+  margin-left: calc(${variables.layoutPadding}*-1);
+  width: calc(100% + ${variables.layoutPadding});
+  position: relative;
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: ${variables.layoutPadding};
+    height: 100%;
+    background: linear-gradient(to left, #fff, transparent);
+    z-index: 1;
+    transform: translateX(100%);
+  }
+  .swiper {
+    padding: 0 ${variables.layoutPadding};
+  }
 `;
 
 const swiperStyle = css`

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -274,7 +274,7 @@ const FilterBoxStyle = styled.div`
 `;
 
 const ListStyle = styled.div`
-  padding-top: 9.6rem;
+  padding-top: 10.8rem;
 `;
 
 export default Home;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -174,6 +174,7 @@ const GlobalStyles = css`
 
   img {
     max-width: 100%;
+    vertical-align: top;
   }
 
   label {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#438 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 슬라이드 양옆 여백 추가
- 스튜디오 리스트 상단 여백 변경 (9.6rem -> 10.8rem)
- img 태그에 하단 여백이 생겨 vertical-align:top 추가

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@aksenmi 지민님! 
슬라이드의 오른쪽 영역이 레이아웃을 뚫고 나오다보니, 포트폴리오가 없는 경우(멋진 사진 준비중)와 레이아웃이 깨진다고 생각이 들었습니다.
따라서 가상 요소로 그라디언트를 추가했습니다! (아래 이미지 참고)
디자인팀과 상의 후 자유롭게 삭제하셔도 됩니다 !

그라디언트 없음 | 그라디언트 있음 (현재 상태) | 
| - | - |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/3bcd1340-894f-4f3a-bb6a-448388f9b5bc" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1c4b7c8f-602a-4bb2-9dca-7fc51bcb51bb" />


@woojoung1217 @JWJung-99 @HuiseonDev @aksenmi @kyungmim 
이미지 태그를 사용시 생기는 하단 여백을 방지하기 위해 이미지 태그에 수직 상단 정렬 값을 추가하였습니다.
작업 분량에 달라진 점이 생길 수 있으니 참고 부탁드립니다 !

수직 상단 정렬 이전 | 수직 상단 정렬 이후 
| - | - |
|  <img width="336" alt="image" src="https://github.com/user-attachments/assets/73a60628-d2bb-4936-9533-8ea3c07b369b" /> |   <img width="333" alt="image" src="https://github.com/user-attachments/assets/87f8389a-959f-4c3a-a2e4-e75c30e2f404" />

