### PR TITLE
[QA2] ImageSwiper pagination 스타일 오류 이슈 해결

### DIFF
--- a/src/components/Swiper/ImageSwiper.tsx
+++ b/src/components/Swiper/ImageSwiper.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { Swiper, SwiperSlide, SwiperProps } from 'swiper/react';
-import 'swiper/css';
 import { Mousewheel, Pagination } from 'swiper/modules';
 import variables from '@styles/Variables';
 import { IPortfolio, IReviewImages } from 'types/types';
 import { useState } from 'react';
+import 'swiper/css';
 
 interface ImageSwiperProps extends SwiperProps {
   images: IPortfolio[] | IReviewImages[];
@@ -46,6 +46,7 @@ const ImageSwiper = ({
   return (
     <div css={conditionalContainerStyle}>
       <Swiper
+        className="imageSwiper"
         css={swiperStyle}
         modules={modules}
         mousewheel={mousewheel}
@@ -88,27 +89,30 @@ const containerDefaultStyle = (isSwiped: boolean) => css`
 const swiperStyle = css`
   width: calc(100% + ${variables.layoutPadding});
 
-  .swiper-pagination {
+  & .swiper-pagination.swiper-pagination-horizontal {
     position: absolute;
+    z-index: 10;
     bottom: 15px;
-    width: 100%;
+    left: 50%;
+    width: 8rem;
     display: flex;
     justify-content: center;
-    z-index: 10;
-  }
+    transform: translateX(-50%);
 
-  .swiper-pagination-bullet {
-    background-color: ${variables.colors.white};
-    opacity: 0.8;
-    width: 20px;
-    height: 3px;
-    transition: all 0.3s ease;
-    margin: 0 1px;
-    cursor: pointer;
-  }
-  .swiper-pagination-bullet-active {
-    background-color: ${variables.colors.black};
-    opacity: 1;
+    & .swiper-pagination-bullet {
+      background-color: ${variables.colors.white};
+      opacity: 0.8;
+      width: 100%;
+      height: 0.2rem;
+      margin: 0;
+      transition: all 0.3s ease;
+      cursor: pointer;
+    }
+
+    & .swiper-pagination-bullet-active {
+      background-color: ${variables.colors.black};
+      opacity: 1;
+    }
   }
 `;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#441 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- ```ImageSwiper```  pagination 스타일 수정
- ```ImageSwiper``` pagination 스타일 오류 해결

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@aksenmi 지민님! 확인 부탁드립니다!

- **문제**
이전에 말씀드린 스타일 중복이 문제가 아니였더라구여! 원인을 찾아보니 CSS 우선순위로 인해 Swiper의 기본 스타일이 Emotion 스타일보다 우선 적용되어서 스타일이 틀어졌던거였습니다!

- **해결**
아래 코드 보시고 이해 안가시면 말씀주세요!
``` js
<Swiper className="imageSwiper"> // swiper 유니크한 클랙스 적용으로 우선순위 높이기

// 위에 유니크한 클래스를 추가하는 것만으로는 해결되지 않아서  Swiper의 기본 클래스를 추가하여 우선순위를 높였습니다!
  & .swiper-pagination.swiper-pagination-horizontal {
    position: absolute;
    z-index: 10;
    bottom: 15px;
    left: 50%;
    width: 8rem;
    display: flex;
    justify-content: center;
    transform: translateX(-50%);

    & .swiper-pagination-bullet {
      background-color: ${variables.colors.white};
      opacity: 0.8;
      width: 100%;
      height: 0.2rem;
      margin: 0;
      transition: all 0.3s ease;
      cursor: pointer;
    }

    & .swiper-pagination-bullet-active {
      background-color: ${variables.colors.black};
      opacity: 1;
    }
  }
```
그리고 수정 전 코드의 pagination은 이미지의 갯수가 늘어나면 pagination의 ```전체 width가 같이 늘어나는데``` 디자인팀에 문의 해본 결과 ```pagination의 전체 width는 고정```이고, 활성화된 pagination의 크기가 이미지 갯수가 늘어날 경우 ```전체 width에 n/1``` 비율로 작아지는것을 의도했다고 하셔서 width값을 조금 수정하였습니다! 
아래 비교 이미지 확인해주시고 수정필요하시면 언제든지 연락주세요!

|수정 전|수정 후|
|------|---|
|![수정전](https://github.com/user-attachments/assets/238d1191-6604-4df5-88bf-0006f463b564)|![수정 후](https://github.com/user-attachments/assets/1c0093f9-dfde-4b18-82d6-7976666f3cb2)|
