### PR TITLE
[WEB1] PC 반응형 설정

### DIFF
--- a/src/pages/Studio/StudioPortfolio/StudioPortfolio.tsx
+++ b/src/pages/Studio/StudioPortfolio/StudioPortfolio.tsx
@@ -15,6 +15,7 @@ import DimmedModal from '../components/DimmedModal';
 import PortfolioSwiper from './PortfolioSwiper';
 import { Hidden } from '@styles/Common';
 import { Helmet } from 'react-helmet-async';
+import variables from '@styles/Variables';
 
 interface IPortfolioResponse {
   menuIdList: number[];
@@ -148,5 +149,5 @@ const listStyle = css`
 `;
 
 const studioPaddingTop = css`
-  padding-top: 5.6rem;
+  padding-top: ${variables.headerHeight};
 `;

--- a/src/styles/BreakPoint.tsx
+++ b/src/styles/BreakPoint.tsx
@@ -1,0 +1,3 @@
+export const breakPoints = {
+  pc: '1024px',
+};

--- a/src/styles/BreakPoint.tsx
+++ b/src/styles/BreakPoint.tsx
@@ -1,3 +1,4 @@
 export const breakPoints = {
   pc: '1024px',
+  moMax: '1023px',
 };

--- a/src/styles/Common.tsx
+++ b/src/styles/Common.tsx
@@ -101,3 +101,29 @@ export const Hidden = css`
   overflow: hidden;
   clip: rect(1px 1px 1px 1px);
 `;
+
+// layout
+export const PCLayout = css`
+  max-width: ${variables.maxWidth};
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: ${variables.layoutPadding};
+  padding-right: ${variables.layoutPadding};
+`;
+
+// 화면 가득 차는 배경
+export const bg100vw = (bg: string) => css`
+  position: relative;
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 100vw;
+    height: 100%;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${bg};
+    z-index: -1;
+  }
+`;

--- a/src/styles/Common.tsx
+++ b/src/styles/Common.tsx
@@ -107,8 +107,6 @@ export const PCLayout = css`
   max-width: ${variables.maxWidth};
   margin-left: auto;
   margin-right: auto;
-  padding-left: ${variables.layoutPadding};
-  padding-right: ${variables.layoutPadding};
 `;
 
 // 화면 가득 차는 배경

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -2,6 +2,7 @@
 import { css } from '@emotion/react';
 import variables from './Variables';
 import { TypoBodyMdR } from './Common';
+import { breakPoints } from './breakPoint';
 
 const GlobalStyles = css`
   @font-face {
@@ -16,6 +17,22 @@ const GlobalStyles = css`
     min-width: 320px;
     min-height: 100svh;
     background: ${variables.colors.white};
+
+    --breakPointPC: 500px;
+
+    --layoutPadding: 1.6rem;
+    --headerHeight: 5.6rem;
+    --maxWidth: 100%;
+
+    @media (min-width: ${breakPoints.pc}) {
+      --layoutPadding: 2.4rem;
+      --headerHeight: 8rem;
+      --maxWidth: 1280px;
+
+      max-width: calc(var(--maxWidth) + calc(var(--layoutPadding) * 2));
+      max-width: var(--maxWidth);
+      margin: 0 auto;
+    }
   }
 
   body {
@@ -25,8 +42,8 @@ const GlobalStyles = css`
     font-size: ${variables.size.medium};
     padding: 0 ${variables.layoutPadding} calc(4rem + ${variables.headerHeight});
 
-    @media (min-width: 1024px) {
-      padding: 0 ${variables.layoutPaddingPC};
+    @media (min-width: ${breakPoints.pc}) {
+      padding-bottom: 0;
     }
   }
 
@@ -323,7 +340,7 @@ const GlobalStyles = css`
   }
 
   /* PC */
-  @media (min-width: 1024px) {
+  @media (min-width: ${breakPoints.pc}) {
     .mo {
       display: none;
     }

--- a/src/styles/Variables.tsx
+++ b/src/styles/Variables.tsx
@@ -39,12 +39,12 @@ const variables = {
     min: '1rem',
   },
 
-  layoutPadding: '1.6rem',
-  layoutPaddingPC: '2.4rem',
+  layoutPadding: 'var(--layoutPadding)',
   TransitionDuration: '0.3s',
   borderRadius: '.8rem',
   borderRadiusLarge: '2rem',
-  headerHeight: '4.8rem',
+  headerHeight: 'var(--headerHeight)',
+  maxWidth: 'var(--maxWidth)',
 };
 
 export default variables;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#463 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- PC 레이아웃 설정
- PC용 Common 변수 정의 : PCLayout, bg100vw
- 포트폴리오 상단 여백 변경 : 5.6rem -> ${variables.headerHeight}

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### 1. 이모션 변수에 mo, pc 값 구분 적용
다음과 같이 변수를 사용해서 값을 변경하고 사용하면 됩니다.
- 변수 설정할 때 : css 변수를 활용해 mo, pc 값을 변경 (GlobalStyles.tsx)
- 변수 사용할 때 : 이모션 변수를 활용해 변수 사용 `${variables.layoutPadding}`

![image](https://github.com/user-attachments/assets/c82ce520-261f-4b1c-95d7-5b6115922f89)

-----

### 2. 미디어 쿼리(반응형) 적용시 참고 (⭐️)
모바일과 다른 디자인을 적용하기 위해 pc 디자인을 적용할 땐 다음과 같이 사용합니다.
`${breakPoints.pc}` 변수를 통해 1024px을 설정했습니다. 
추후 분기점이 수정되면 한 번에 변경을 위함이니, 꼭 변수를 사용해서 반응형 작업을 해주세요 !

```tsx
export const breakPoints = {
  pc: '1024px',
  moMax: '1023px',
};
```

```tsx
body {
  // 어쩌구 저쩌구 모바일 스타일 적용

  @media (min-width: ${breakPoints.pc}) {
    // pc 스타일 적용
  }
}
```
-----

### 3. PC 디자인을 위한 공통 Common 스타일 정의 (⭐️)

PC 스타일을 편리하게 작업하기 위해 공통 스타일을 정의하였습니다.
- PCLayout : 1280 기준 가운데 정렬되는 상자
- bg100vw('색상') : 색상을 전달하여 100vw로 깔린 배경 설정 (이미지 참고)

![image](https://github.com/user-attachments/assets/8b61834f-de48-4eee-a300-7a7bb8857f33)

```tsx
.element {
  ${bg100vw('#000')}
}
```

-----

### 4. 헤더 fixed로 콘텐츠 겹침 해결 (⭐️)

헤더 높이만큼 콘텐츠에 상단 여백을 부여해야 합니다.
모바일, 피씨를 고려한 헤더 높이를 변수로 설정했으니 사용 부탁드립니다.

```tsx
const studioPaddingTop = css`
  padding-top: ${variables.headerHeight};
`;
```