### PR TITLE
[S5] 예약취소 완료 화면 id 추출 방식 변경

### DIFF
--- a/src/pages/Reservation/ReservationCanceled.tsx
+++ b/src/pages/Reservation/ReservationCanceled.tsx
@@ -1,13 +1,16 @@
 import { changeformatDateForUi, convertToDateFormat, today } from '@store/useSelectDateStore';
+import { useParams } from 'react-router-dom';
 import CompleteMessage from './components/CompleteMessage';
 
 const ReservationCanceled = () => {
-  // 임시 데이터
+  const { _id } = useParams() as { _id: string };
+
+  // 임시 데이터 => _id를 이용해 조회하도록 변경
   const date = convertToDateFormat(today);
   const time = ['13:00'];
 
   const reservationData = {
-    id: 1,
+    id: Number(_id),
     studio: '그믐달 스튜디오',
     reservedDateTime: changeformatDateForUi({ date, time }),
     reservedMenu: '프로필 A 반신 촬영',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -134,7 +134,6 @@ const router = createBrowserRouter([
               { path: 'photos', element: <StudioReviewPhotos /> },
             ],
           },
-
           {
             path: 'reservation',
             children: [
@@ -169,7 +168,6 @@ const router = createBrowserRouter([
               { path: 'review/write', element: <StudioReviewWritePage /> },
             ],
           },
-          {},
         ],
       },
     ],


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#489 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 예약 취소 후 예약 id를 웹 스토리지에서 받지 않고 경로에서 추출하는 방식으로 변경하였습니다.
- API가 완성되면 해당 id를 이용하여 예약 상세 내역을 fetch 하여 불러올 예정입니다. (현재는 임시)

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@s0zzang 취소 후 `/reservation/_id(예약 id)/canceled` 경로로 보내주시면 됩니다요