### PR TITLE
[WEB1] 반응형 가격 세션 구현 PC 작업 공유

### DIFF
--- a/src/components/FilterPriceSlide/FilterPriceSlide.tsx
+++ b/src/components/FilterPriceSlide/FilterPriceSlide.tsx
@@ -163,11 +163,12 @@ const FilterPriceRangeMin = styled.input`
   z-index: 1;
 
   &::-webkit-slider-thumb {
-    height: 2.6rem;
+    height: 2.7rem;
     pointer-events: auto;
-    width: 2.6rem;
+    width: 2.7rem;
     border-radius: 50%;
-    border: 0.1rem solid ${variables.colors.primary};
+    border: 0.2rem solid ${variables.colors.primary};
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     background-color: #fff8e1;
     -webkit-appearance: none;
     z-index: 99;
@@ -183,7 +184,7 @@ const PriceRangeTrack = styled.div`
   left: 0;
   right: 0;
   transform: translateY(-50%);
-  width: 100%;
+  width: 99%;
   height: 0.8rem;
   background-color: ${variables.colors.gray200};
   border-radius: ${variables.borderRadius};
@@ -191,7 +192,7 @@ const PriceRangeTrack = styled.div`
 
 const TrackFilled = styled.div`
   position: absolute;
-  height: 0.8rem;
+  height: 0.9rem;
   background-color: ${variables.colors.primary700};
 `;
 

--- a/src/components/FilterPriceSlide/FilterPriceSlidePC.tsx
+++ b/src/components/FilterPriceSlide/FilterPriceSlidePC.tsx
@@ -4,9 +4,22 @@ import Input from '@components/Input/Input';
 import { css } from '@emotion/react';
 import { TypoBodyMdSb, TypoBodySmR } from '@styles/Common';
 import variables from '@styles/Variables';
+import { useFilterStore } from '@store/useFilterStore';
 
 /** PC 버전 가격 필터링 기능  */
 const FilterPriceSlidePC = () => {
+  const { minPrice, maxPrice, setMinPrice, setMaxPrice } = useFilterStore();
+
+  const handleMinPriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value.replace(/,/g, ''));
+    setMinPrice(value.toString());
+  };
+
+  const handleMaxPriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value.replace(/,/g, ''));
+    setMaxPrice(value.toString());
+  };
+
   return (
     <div>
       <h2
@@ -32,6 +45,8 @@ const FilterPriceSlidePC = () => {
           placeholder="10,000"
           inputWidth="14rem"
           borderRadius=".8rem"
+          value={minPrice ? minPrice.toLocaleString() : ''}
+          onChange={handleMinPriceChange}
         />
         <span
           css={css`
@@ -59,6 +74,8 @@ const FilterPriceSlidePC = () => {
           placeholder="200,000"
           inputWidth="14rem"
           borderRadius=".8rem"
+          value={maxPrice ? maxPrice.toLocaleString() : ''}
+          onChange={handleMaxPriceChange}
         />
         <span
           css={css`

--- a/src/components/FilterPriceSlide/FilterPriceSlidePC.tsx
+++ b/src/components/FilterPriceSlide/FilterPriceSlidePC.tsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource @emotion/react */
+
+import Input from '@components/Input/Input';
+import { css } from '@emotion/react';
+import { TypoBodyMdSb, TypoBodySmR } from '@styles/Common';
+import variables from '@styles/Variables';
+
+/** PC 버전 가격 필터링 기능  */
+const FilterPriceSlidePC = () => {
+  return (
+    <div>
+      <h2
+        css={css`
+          ${TypoBodyMdSb}
+          color: ${variables.colors.gray800};
+          margin-bottom: 0.8rem;
+        `}
+      >
+        가격
+      </h2>
+      <div
+        css={css`
+          width: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        `}
+      >
+        <Input
+          labelName="최소가격"
+          type="money"
+          placeholder="10,000"
+          inputWidth="14rem"
+          borderRadius=".8rem"
+        />
+        <span
+          css={css`
+            ${TypoBodySmR}
+            min-width: 4.5rem;
+            margin-top: 2rem;
+            color: ${variables.colors.gray900};
+          `}
+        >
+          원 부터
+        </span>
+      </div>
+
+      <div
+        css={css`
+          width: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        `}
+      >
+        <Input
+          labelName="최대가격"
+          type="money"
+          placeholder="200,000"
+          inputWidth="14rem"
+          borderRadius=".8rem"
+        />
+        <span
+          css={css`
+            ${TypoBodySmR}
+            min-width: 4.5rem;
+            margin-top: 2rem;
+            color: ${variables.colors.gray900};
+          `}
+        >
+          원 까지
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default FilterPriceSlidePC;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -18,6 +18,7 @@ interface InputProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   checkButtonText?: string;
   inputWidth?: string;
+  defaultValue?: string;
   isValid?: boolean;
 }
 
@@ -32,8 +33,9 @@ const Input = ({
   checkButtonText = '중복확인',
   inputWidth = '100%',
   isValid,
+  defaultValue,
 }: InputProps) => {
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(defaultValue || '');
   const [showPassword, setShowPassword] = useState(false);
   const [isActive, setIsActive] = useState(false);
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -36,6 +36,7 @@ const Input = ({
   isValid,
   defaultValue,
   borderRadius = '0.6rem',
+  onChange,
 }: InputProps) => {
   const [inputValue, setInputValue] = useState(defaultValue || '');
   const [showPassword, setShowPassword] = useState(false);
@@ -54,15 +55,21 @@ const Input = ({
     if (initialType === 'money') {
       const formattedValue = formatMoney(e.target.value);
       setInputValue(formattedValue);
-      if (register?.onChange) {
+
+      if (onChange) {
         const event = {
           ...e,
           target: { ...e.target, value: formattedValue },
         } as React.ChangeEvent<HTMLInputElement>;
-        register.onChange(event);
+        onChange(event);
+      }
+
+      if (register?.onChange) {
+        register.onChange(e);
       }
     } else {
       setInputValue(e.target.value);
+      onChange?.(e);
       register?.onChange?.(e);
     }
   };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 
 interface InputProps {
   labelName: string;
-  type: string;
+  type?: string;
   value?: string;
   placeholder: string;
   error?: string;
@@ -20,6 +20,7 @@ interface InputProps {
   inputWidth?: string;
   defaultValue?: string;
   isValid?: boolean;
+  borderRadius?: string;
 }
 
 const Input = ({
@@ -34,14 +35,36 @@ const Input = ({
   inputWidth = '100%',
   isValid,
   defaultValue,
+  borderRadius = '0.6rem',
 }: InputProps) => {
   const [inputValue, setInputValue] = useState(defaultValue || '');
   const [showPassword, setShowPassword] = useState(false);
   const [isActive, setIsActive] = useState(false);
 
+  /** 머니 포맷터 */
+  const formatMoney = (value: string) => {
+    // 숫자가 아닌 문자 제거
+    const numbers = value.replace(/[^\d]/g, '');
+    // 천 단위 쉼표 추가
+    return numbers.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  /** 인풋 타입이 money 인 경우 값을 쉼표 단위로 변경해주는 함수 */
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-    register?.onChange?.(e);
+    if (initialType === 'money') {
+      const formattedValue = formatMoney(e.target.value);
+      setInputValue(formattedValue);
+      if (register?.onChange) {
+        const event = {
+          ...e,
+          target: { ...e.target, value: formattedValue },
+        } as React.ChangeEvent<HTMLInputElement>;
+        register.onChange(event);
+      }
+    } else {
+      setInputValue(e.target.value);
+      register?.onChange?.(e);
+    }
   };
 
   const handleClear = () => {
@@ -73,7 +96,7 @@ const Input = ({
         <div css={inputContainerStyle}>
           <div css={inputWrapperStyle}>
             <input
-              css={inputStyle(error, isValid)}
+              css={inputStyle(error, isValid, borderRadius)}
               type={type}
               placeholder={placeholder}
               autoComplete="off"
@@ -132,7 +155,7 @@ const labelStyle = css`
   ${TypoBodySmM}
 `;
 
-const inputStyle = (error?: string, isValid?: boolean) => css`
+const inputStyle = (error?: string, isValid?: boolean, borderRadius?: string) => css`
   && {
     margin-top: 0.4rem;
     margin-bottom: 0.4rem;
@@ -141,7 +164,7 @@ const inputStyle = (error?: string, isValid?: boolean) => css`
     box-sizing: border-box;
     padding: 1rem 6rem 1rem 1rem;
     border: 1px solid ${error ? 'red' : isValid ? 'green' : variables.colors.gray300};
-    border-radius: 0.6rem;
+    border-radius: ${borderRadius};
     background-color: ${variables.colors.white};
     font-size: 1.6rem;
     letter-spacing: normal;

--- a/src/components/ServiceAvailability/ServiceAvailability.tsx
+++ b/src/components/ServiceAvailability/ServiceAvailability.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@components/Button/Button';
 import styled from '@emotion/styled';
@@ -8,6 +8,7 @@ import useBottomSheetState from '@store/useBottomSheetStateStore';
 import { css } from '@emotion/react';
 import { TypoBodyMdSb } from '@styles/Common';
 import variables from '@styles/Variables';
+import { useFilterStore } from '@store/useFilterStore';
 
 interface ServiceAvailabilityProps {
   isPc?: boolean; // PC 환경인지 여부를 전달받는 prop
@@ -16,6 +17,7 @@ interface ServiceAvailabilityProps {
 /** 필터링 시 매장 서비스 제공 여부를 선택하는 컴포넌트 */
 const ServiceAvailability = ({ isPc = false }: ServiceAvailabilityProps) => {
   const [selectedButtons, setSelectedButtons] = useState<number[]>([]);
+  const { setSelectedServices } = useFilterStore();
   const navigate = useNavigate();
 
   const { closeBottomSheet } = useBottomSheetState(); // 바텀 시트 닫는 함수 호출
@@ -27,6 +29,15 @@ const ServiceAvailability = ({ isPc = false }: ServiceAvailabilityProps) => {
       return newSelected; // 선택된 버튼 목록 업데이트
     });
   };
+
+  // PC 모드일 때 선택된 버튼이 변경되면 전역 상태 업데이트
+  useEffect(() => {
+    if (isPc) {
+      const selectedServices = selectedButtons.map((i) => getButtonTitle(i));
+      setSelectedServices(selectedServices);
+      console.log('서비스 선택 변경:', selectedServices);
+    }
+  }, [selectedButtons, isPc, setSelectedServices]);
 
   /** "적용하기" 버튼 클릭 시 선택된 버튼의 제목을 쿼리 파라미터로 변환하여 네비게이션하는 함수 */
   const handleApplyClick = () => {

--- a/src/components/ServiceAvailability/ServiceAvailability.tsx
+++ b/src/components/ServiceAvailability/ServiceAvailability.tsx
@@ -1,11 +1,20 @@
+/** @jsxImportSource @emotion/react */
+
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@components/Button/Button';
 import styled from '@emotion/styled';
 import useBottomSheetState from '@store/useBottomSheetStateStore';
+import { css } from '@emotion/react';
+import { TypoBodyMdSb } from '@styles/Common';
+import variables from '@styles/Variables';
+
+interface ServiceAvailabilityProps {
+  isPc?: boolean; // PC 환경인지 여부를 전달받는 prop
+}
 
 /** 필터링 시 매장 서비스 제공 여부를 선택하는 컴포넌트 */
-const ServiceAvailability = () => {
+const ServiceAvailability = ({ isPc = false }: ServiceAvailabilityProps) => {
   const [selectedButtons, setSelectedButtons] = useState<number[]>([]);
   const navigate = useNavigate();
 
@@ -43,21 +52,18 @@ const ServiceAvailability = () => {
   };
   return (
     <>
+      {isPc && (
+        <h2
+          css={css`
+            ${TypoBodyMdSb}
+            color: ${variables.colors.gray800};
+            margin-bottom: 0.8rem;
+          `}
+        >
+          매장정보 서비스
+        </h2>
+      )}
       <ServiceAvailabilityContainerStyle>
-        <Button
-          icon={<img src="img/icon-photo-edit.svg" alt="1:1보정" />}
-          iconSizeWidth="2.4rem"
-          iconSizeHeight="2.4rem"
-          iconPosition="left"
-          size="medium"
-          text={`1:1 보정`}
-          width="fit"
-          variant="white"
-          disabled={selectedButtons.includes(0)}
-          active={selectedButtons.includes(0)}
-          onClick={() => handleButtonClick(0)}
-          type="button"
-        />
         <Button
           icon={<img src="img/icon-original-file.svg" alt="원본 파일 제공" />}
           iconSizeWidth="2.4rem"
@@ -70,6 +76,20 @@ const ServiceAvailability = () => {
           disabled={selectedButtons.includes(1)}
           active={selectedButtons.includes(1)}
           onClick={() => handleButtonClick(1)}
+          type="button"
+        />
+        <Button
+          icon={<img src="img/icon-photo-edit.svg" alt="1:1보정" />}
+          iconSizeWidth="2.4rem"
+          iconSizeHeight="2.4rem"
+          iconPosition="left"
+          size="medium"
+          text={`1:1 보정`}
+          width="fit"
+          variant="white"
+          disabled={selectedButtons.includes(0)}
+          active={selectedButtons.includes(0)}
+          onClick={() => handleButtonClick(0)}
           type="button"
         />
         <Button
@@ -143,26 +163,30 @@ const ServiceAvailability = () => {
           type="button"
         />
       </ServiceAvailabilityContainerStyle>
-      <ButtonWrapperStyle>
-        <Button
-          size="large"
-          disabled={false}
-          text={`초기화`}
-          width="fit"
-          variant="gray"
-          onClick={handleResetClick}
-          type="button"
-        />
-        <Button
-          size="large"
-          disabled={false}
-          text={`적용하기`}
-          width="max"
-          variant="black"
-          onClick={handleApplyClick}
-          type="button"
-        />
-      </ButtonWrapperStyle>
+
+      {/* PC 환경이 아닐 때만 버튼들을 렌더링 */}
+      {!isPc && (
+        <ButtonWrapperStyle>
+          <Button
+            size="large"
+            disabled={false}
+            text={`초기화`}
+            width="fit"
+            variant="gray"
+            onClick={handleResetClick}
+            type="button"
+          />
+          <Button
+            size="large"
+            disabled={false}
+            text={`적용하기`}
+            width="max"
+            variant="black"
+            onClick={handleApplyClick}
+            type="button"
+          />
+        </ButtonWrapperStyle>
+      )}
     </>
   );
 };

--- a/src/hooks/useStudioReviews.ts
+++ b/src/hooks/useStudioReviews.ts
@@ -45,7 +45,8 @@ export const useStudioReviews = (studioId: string | undefined, menuId: number | 
     queryFn: fetchStudioReviews,
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 30, // 30분
-    retry: 3,
+    retry: 2,
     enabled: !!studioId,
+    throwOnError: true,
   });
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -15,7 +15,7 @@ import styled from '@emotion/styled';
 import useGetWindowWidth from '@hooks/useGetWindowWidth';
 import useBottomSheetState from '@store/useBottomSheetStateStore';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
-import { bg100vw, Hidden, PCLayout, TypoBodyMdSb } from '@styles/Common';
+import { bg100vw, PCLayout, TypoBodyMdSb } from '@styles/Common';
 import variables from '@styles/Variables';
 import { decodeSearchParamsToString } from '@utils/decodeSearchParams';
 import { remToPx } from '@utils/remToPx';
@@ -23,6 +23,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import LocalDateSelectionModal from './components/LocalDateSelectionModal';
+import PCFilterWrapper from './components/PCFilterWrapper';
 
 interface IFixedProps {
   isFixed: boolean;
@@ -210,47 +211,8 @@ const Home = () => {
           {/* PC 필터 영역 */}
           <FilterSectionStyle className="pc" isFixed={isFixed}>
             <FilterContentStyle>
-              <div className="filter-sort">
-                <p>매장 정렬</p>
-                <div>정렬 영역</div>
-              </div>
-
-              <div className="filter-price">
-                <p>가격</p>
-                <div>가격 필터 영역</div>
-              </div>
-
-              <div className="filter-options">
-                <p>매장 정보·서비스</p>
-                <div>매장 정보·서비스 필터 영역</div>
-              </div>
+              <PCFilterWrapper />
             </FilterContentStyle>
-            <FilterButtonBoxStyle>
-              <ButtonWrapperStyle onClick={handleReset} className={isAnimating ? 'rotateIcon' : ''}>
-                <span css={Hidden}>초기화</span>
-                <Button
-                  text=""
-                  type="reset"
-                  variant="gray"
-                  icon={
-                    <RotateIconStyle
-                      className={isAnimating ? 'rotateIcon' : ''}
-                      src="/img/icon-reset.svg"
-                      alt="필터 초기화"
-                    />
-                  }
-                  onClick={handleReset}
-                />
-              </ButtonWrapperStyle>
-              <Button
-                type="button"
-                size="medium"
-                text={`필터 적용하기`}
-                width="max"
-                variant="black"
-                onClick={() => {}}
-              />
-            </FilterButtonBoxStyle>
           </FilterSectionStyle>
           <ListStyle>
             <StudioList mode="filter" searchParams={searchParams} />
@@ -396,20 +358,6 @@ const FilterContentStyle = styled.div`
     margin-top: 2rem;
     margin-bottom: 3.4rem;
   }
-`;
-
-const FilterButtonBoxStyle = styled.div`
-  background-color: ${variables.colors.white};
-  padding: 1.6rem 0 2.6rem;
-  position: fixed;
-  width: 19.2rem;
-  z-index: 9;
-  bottom: 0;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.8rem;
 `;
 
 const ListStyle = styled.div`

--- a/src/pages/Home/components/PCFilterWrapper.tsx
+++ b/src/pages/Home/components/PCFilterWrapper.tsx
@@ -1,13 +1,120 @@
+/** @jsxImportSource @emotion/react */
+
 import FilterPriceSlidePC from '@components/FilterPriceSlide/FilterPriceSlidePC';
 import ServiceAvailability from '@components/ServiceAvailability/ServiceAvailability';
+import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { decodeSearchParamsToString } from '@utils/decodeSearchParams';
+import Button from '@components/Button/Button';
+import styled from '@emotion/styled';
+import variables from '@styles/Variables';
+import { keyframes } from '@emotion/react';
+import { Hidden } from '@styles/Common';
+import { useFilterStore } from '@store/useFilterStore';
 
 const PCFilterWrapper = () => {
+  const [searchParams] = useSearchParams();
+  const [isAnimating, setIsAnimating] = useState(false);
+  const navigate = useNavigate();
+  const { minPrice, maxPrice, selectedServices, resetFilter } = useFilterStore();
+
+  // URL 파라미터 기준으로 필터 적용 상태 확인
+  const hasAppliedFilters = () => {
+    return (
+      searchParams.has('minPrice') || searchParams.has('maxPrice') || searchParams.has('options')
+    );
+  };
+
+  const handleApplyFilter = () => {
+    const params = new URLSearchParams(searchParams);
+
+    if (minPrice) params.set('minPrice', minPrice);
+    if (maxPrice) params.set('maxPrice', maxPrice);
+    if (selectedServices.length > 0) {
+      params.set('options', selectedServices.join('%'));
+    }
+
+    navigate(`?${decodeSearchParamsToString(params)}`);
+  };
+
+  const handleReset = () => {
+    setIsAnimating(false);
+    setTimeout(() => setIsAnimating(true), 50);
+    // 전역 상태 초기화
+    resetFilter();
+    window.location.href = '';
+    // URL 파라미터 초기화
+    const paramsToDelete = ['sortBy', 'minPrice', 'maxPrice', 'options'];
+    paramsToDelete.forEach((param) => searchParams.delete(param));
+    navigate(`?${decodeSearchParamsToString(searchParams)}`);
+  };
+
   return (
     <>
       <FilterPriceSlidePC />
       <ServiceAvailability isPc={true} />
+
+      <FilterButtonBoxStyle>
+        <ButtonWrapperStyle onClick={handleReset} className={isAnimating ? 'rotateIcon' : ''}>
+          <span css={Hidden}>초기화</span>
+          <Button
+            text=""
+            type="reset"
+            variant="gray"
+            icon={
+              <RotateIconStyle
+                className={isAnimating ? 'rotateIcon' : ''}
+                src="/img/icon-reset.svg"
+                alt="필터 초기화"
+              />
+            }
+            onClick={handleReset}
+          />
+        </ButtonWrapperStyle>
+        <Button
+          type="button"
+          size="medium"
+          text={hasAppliedFilters() ? '적용 중' : '필터 적용하기'}
+          width="max"
+          variant="black"
+          onClick={handleApplyFilter}
+        />
+      </FilterButtonBoxStyle>
     </>
   );
 };
 
 export default PCFilterWrapper;
+
+const FilterButtonBoxStyle = styled.div`
+  background-color: ${variables.colors.white};
+  padding: 1.6rem 0 2.6rem;
+  position: fixed;
+  width: 19.2rem;
+  z-index: 9;
+  bottom: 0;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+`;
+
+const ButtonWrapperStyle = styled.div`
+  display: inline-block;
+`;
+
+const rotateIcon = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const RotateIconStyle = styled.img`
+  &.rotateIcon {
+    animation: ${rotateIcon} 0.4s ease-out;
+  }
+`;

--- a/src/pages/Home/components/PCFilterWrapper.tsx
+++ b/src/pages/Home/components/PCFilterWrapper.tsx
@@ -1,0 +1,13 @@
+import FilterPriceSlidePC from '@components/FilterPriceSlide/FilterPriceSlidePC';
+import ServiceAvailability from '@components/ServiceAvailability/ServiceAvailability';
+
+const PCFilterWrapper = () => {
+  return (
+    <>
+      <FilterPriceSlidePC />
+      <ServiceAvailability isPc={true} />
+    </>
+  );
+};
+
+export default PCFilterWrapper;

--- a/src/pages/Studio/StudioReview/StudioReview.tsx
+++ b/src/pages/Studio/StudioReview/StudioReview.tsx
@@ -85,6 +85,7 @@ const StudioReview = () => {
             <p css={TypoCapSmR}>{totalImageNum}개</p>
           </ReviewTitleWrapperStyle>
           {/* 리뷰 이미지 모아보기 컴포넌트 */}
+
           <StudioReviewImageList pageId={_id} samplePhotoList={samplePhotoList} />
         </ReviewPhotosWrapperStyle>
         {/* 스튜디오 리뷰 카테고리 */}

--- a/src/pages/Studio/StudioReview/StudioReview.tsx
+++ b/src/pages/Studio/StudioReview/StudioReview.tsx
@@ -5,12 +5,14 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import StudioReviewImageList from './components/StudioReviewImageList';
 import StudioNavigator from '@components/Navigator/StudioNavigator';
 import StudioReviewItem from './components/StudioReviewItem';
+import { css } from '@emotion/react';
 import StudioReviewCategories from './components/StudioReviewCategories';
 import { IReviewImages } from 'types/types';
 import { useStudioReviews } from '@hooks/useStudioReviews';
 import Header from '@components/Header/Header';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
+import variables from '@styles/Variables';
 // 리뷰 데이터의 타입 정의
 interface Review {
   content: string;
@@ -76,29 +78,33 @@ const StudioReview = () => {
 
       <Header title="리뷰" />
       <StudioNavigator _id={_id || ''} />
-      <ReviewPhotosWrapperStyle>
-        <ReviewTitleWrapperStyle>
-          <h1 css={TypoTitleXsM}>리뷰 사진 모아보기</h1>
-          <p css={TypoCapSmR}>{totalImageNum}개</p>
-        </ReviewTitleWrapperStyle>
-        <StudioReviewImageList pageId={_id} samplePhotoList={samplePhotoList} />
-      </ReviewPhotosWrapperStyle>
-
-      <StudioReviewCategories
-        avgRating={Number(processedAvgRating)}
-        totalReviewNum={totalReviewNum}
-        menuNameList={menuNameList}
-        menuIdList={menuIdList || []}
-        onFilterChange={handleFilterChange}
-      />
-      {reviewLists.map((review: Review, index: number) => (
-        <StudioReviewItem
-          showMenuName={true}
-          key={review.id}
-          review={review}
-          isLast={index === reviewLists.length - 1}
+      <div css={studioPaddingTop}>
+        <ReviewPhotosWrapperStyle>
+          <ReviewTitleWrapperStyle>
+            <h1 css={TypoTitleXsM}>리뷰 사진 모아보기</h1>
+            <p css={TypoCapSmR}>{totalImageNum}개</p>
+          </ReviewTitleWrapperStyle>
+          {/* 리뷰 이미지 모아보기 컴포넌트 */}
+          <StudioReviewImageList pageId={_id} samplePhotoList={samplePhotoList} />
+        </ReviewPhotosWrapperStyle>
+        {/* 스튜디오 리뷰 카테고리 */}
+        <StudioReviewCategories
+          avgRating={Number(processedAvgRating)}
+          totalReviewNum={totalReviewNum}
+          menuNameList={menuNameList}
+          menuIdList={menuIdList || []}
+          onFilterChange={handleFilterChange}
         />
-      ))}
+        {/* 리뷰 리스트 렌더링  */}
+        {reviewLists.map((review: Review, index: number) => (
+          <StudioReviewItem
+            showMenuName={true}
+            key={review.id}
+            review={review}
+            isLast={index === reviewLists.length - 1}
+          />
+        ))}
+      </div>
     </>
   );
 };
@@ -119,4 +125,7 @@ const ReviewTitleWrapperStyle = styled.div`
     justify-content: center;
     align-items: center;
   }
+`;
+const studioPaddingTop = css`
+  padding-top: ${variables.headerHeight};
 `;

--- a/src/pages/Studio/StudioReview/StudioReview.tsx
+++ b/src/pages/Studio/StudioReview/StudioReview.tsx
@@ -31,10 +31,9 @@ interface Review {
 const StudioReview = () => {
   const { _id } = useParams();
   const [selectedMenuId, setSelectedMenuId] = useState<number | null>(null);
-  const { data, isLoading, error } = useStudioReviews(_id, selectedMenuId);
+  const { data } = useStudioReviews(_id, selectedMenuId);
   const [_, setSearchParams] = useSearchParams();
-  if (isLoading) return <div>로딩중...</div>;
-  if (error) return <div>에러가 발생했습니다</div>;
+
   if (!data) return null;
 
   const {

--- a/src/pages/Studio/StudioReview/StudioReviewPhotos.tsx
+++ b/src/pages/Studio/StudioReview/StudioReviewPhotos.tsx
@@ -12,6 +12,8 @@ import { Helmet } from 'react-helmet-async';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { IReviewImages } from 'types/types';
 import ReviewSwiper from './components/ReviewSwiper';
+import variables from '@styles/Variables';
+import { css } from '@emotion/react';
 
 interface IReviewImagesResponse {
   totalElements: number;
@@ -21,6 +23,7 @@ interface IReviewImagesResponse {
   menuIdList: number[];
 }
 
+/** 리뷰 사진 모아보기 페이지 */
 const StudioReviewPhotos = () => {
   const { _id } = useParams(); // 스튜디오 아이디
   const [selectedMenuId, setSelectedMenuId] = useState<number | null>(null);
@@ -51,7 +54,7 @@ const StudioReviewPhotos = () => {
     return response.json();
   };
 
-  const { data: reviewImages, error } = useQuery<IReviewImagesResponse>({
+  const { data: reviewImages } = useQuery<IReviewImagesResponse>({
     queryKey: ['reviewImages', _id, selectedMenuId],
     queryFn: fetchReviewImage,
     enabled: !!_id,
@@ -60,7 +63,6 @@ const StudioReviewPhotos = () => {
     retry: 3,
   });
 
-  if (error) return <div>에러가 발생했습니다</div>;
   if (!reviewImages) return null;
 
   return (
@@ -73,44 +75,46 @@ const StudioReviewPhotos = () => {
       )}
 
       <Header title="리뷰 사진 모아보기" />
-      <StudioReviewPhotosContainerStyle>
-        <ButtonWrapperStyle>
-          <Button
-            text="전체"
-            variant="white"
-            active={selectedMenuId === null}
-            size="small"
-            width="fit"
-            onClick={() => setSelectedMenuId(null)}
-          />
-          {reviewImages.menuNameList.map((menu, index) => (
+      <div css={studioPaddingTop}>
+        <StudioReviewPhotosContainerStyle>
+          <ButtonWrapperStyle>
             <Button
-              key={menu}
-              text={menu}
+              text="전체"
               variant="white"
-              active={selectedMenuId === reviewImages.menuIdList[index]}
+              active={selectedMenuId === null}
               size="small"
               width="fit"
-              onClick={() => setSelectedMenuId(reviewImages.menuIdList[index])}
+              onClick={() => setSelectedMenuId(null)}
             />
-          ))}
-        </ButtonWrapperStyle>
+            {reviewImages.menuNameList.map((menu, index) => (
+              <Button
+                key={menu}
+                text={menu}
+                variant="white"
+                active={selectedMenuId === reviewImages.menuIdList[index]}
+                size="small"
+                width="fit"
+                onClick={() => setSelectedMenuId(reviewImages.menuIdList[index])}
+              />
+            ))}
+          </ButtonWrapperStyle>
 
-        <MasonryList>
-          {reviewImages.imageDtos.map(({ id, url }) => (
-            <div key={id} onClick={() => handleClick(id)}>
-              <picture>
-                <source srcSet={url.replace(/\.(jpg|jpeg|png)$/, '.webp')} type="image/webp" />
-                <img src={url} alt={`리뷰 이미지 ${id}`} />
-              </picture>
-            </div>
-          ))}
-        </MasonryList>
+          <MasonryList>
+            {reviewImages.imageDtos.map(({ id, url }) => (
+              <div key={id} onClick={() => handleClick(id)}>
+                <picture>
+                  <source srcSet={url.replace(/\.(jpg|jpeg|png)$/, '.webp')} type="image/webp" />
+                  <img src={url} alt={`리뷰 이미지 ${id}`} />
+                </picture>
+              </div>
+            ))}
+          </MasonryList>
 
-        <DimmedModal>
-          <ReviewSwiper data={reviewImages.imageDtos} />
-        </DimmedModal>
-      </StudioReviewPhotosContainerStyle>
+          <DimmedModal>
+            <ReviewSwiper data={reviewImages.imageDtos} />
+          </DimmedModal>
+        </StudioReviewPhotosContainerStyle>
+      </div>
     </>
   );
 };
@@ -125,4 +129,7 @@ const ButtonWrapperStyle = styled.div`
   gap: 0.8rem;
   padding: 1.2rem 0;
   width: 100%;
+`;
+const studioPaddingTop = css`
+  padding-top: ${variables.headerHeight};
 `;

--- a/src/pages/Studio/StudioReview/StudioReviewWritePage.tsx
+++ b/src/pages/Studio/StudioReview/StudioReviewWritePage.tsx
@@ -8,6 +8,7 @@ import Button from '@components/Button/Button';
 import ImageUploadPreview from './components/ImageUploadPreview';
 import TextArea from '@components/TextArea/TextArea';
 import { useState } from 'react';
+import ReservationCard from '@components/ReservationCard/ReservationCard';
 
 /** 리뷰 작성 페이지  */
 const StudioReviewWritePage = () => {
@@ -26,77 +27,73 @@ const StudioReviewWritePage = () => {
   return (
     <main>
       <Header title="리뷰 작성하기" />
+      <div css={studioPaddingTop}>
+        <section>
+          <h2
+            css={css`
+              ${TypoTitleXsM}
+              margin: 1rem 0rem;
+            `}
+          >
+            촬영 어떠셨나요?
+          </h2>
+          <ReservationCard data={null} />
 
-      <section>
-        <h2
-          css={css`
-            ${TypoTitleXsM}
-            margin-top: 1.6rem;
-          `}
-        >
-          촬영 어떠셨나요?
-        </h2>
-        <div
-          css={css`
-            margin-top: 0.8rem;
-            width: 100%;
-            height: 12.7rem;
-            background-color: ${variables.colors.gray100};
-            margin-bottom: 1rem;
-          `}
-        >
-          내용1
-        </div>
-        <StarInput onRatingChange={handleRatingChange} />
-      </section>
+          <StarInput onRatingChange={handleRatingChange} />
+        </section>
 
-      <div css={DividerStyle}></div>
+        <div css={DividerStyle}></div>
 
-      <section>
-        <h3
-          css={css`
-            ${TypoTitleXsM}
-            margin-top: 1.6rem;
-            margin-bottom: 1.6rem;
-          `}
-        >
-          사진 첨부
-        </h3>
-        <div>
-          <ImageUploadPreview maxImages={5} onImagesChange={handleImagesChange} />
-        </div>
-      </section>
+        <section>
+          <h3
+            css={css`
+              ${TypoTitleXsM}
+              margin-top: 1.6rem;
+              margin-bottom: 1.6rem;
+            `}
+          >
+            사진 첨부
+          </h3>
+          <div>
+            <ImageUploadPreview maxImages={5} onImagesChange={handleImagesChange} />
+          </div>
+        </section>
 
-      <div css={DividerStyle}></div>
+        <div css={DividerStyle}></div>
 
-      <section>
-        <h4
-          css={css`
-            ${TypoTitleXsM}
-            margin-top: 1.6rem;
-          `}
-        >
-          리뷰 작성
-        </h4>
-        <div
-          css={css`
-            width: 100%;
-            margin-top: 1.5rem;
-            margin-bottom: 5rem;
-          `}
-        >
-          <TextArea
-            placeholder="리뷰를 작성해주세요."
-            setTextArea={setTextArea}
-            minHeight="15.6rem"
-            maxLength={1000}
-          />
-        </div>
-      </section>
+        <section>
+          <h4
+            css={css`
+              ${TypoTitleXsM}
+              margin-top: 1.6rem;
+            `}
+          >
+            리뷰 작성
+          </h4>
+          <div
+            css={css`
+              width: 100%;
+              margin-top: 1.5rem;
+              margin-bottom: 5rem;
+            `}
+          >
+            <TextArea
+              placeholder="리뷰를 작성해주세요."
+              setTextArea={setTextArea}
+              minHeight="15.6rem"
+              maxLength={1000}
+            />
+          </div>
+        </section>
+      </div>
 
       <Button type="submit" text="등록하기" size="large" variant="black" disabled={!true} />
     </main>
   );
 };
+
+const studioPaddingTop = css`
+  padding-top: ${variables.headerHeight};
+`;
 
 export default StudioReviewWritePage;

--- a/src/pages/Studio/StudioReview/components/StarInput.tsx
+++ b/src/pages/Studio/StudioReview/components/StarInput.tsx
@@ -48,7 +48,10 @@ const StarInput = ({ onRatingChange }: StarInputProps) => {
   return (
     <div
       css={css`
+        margin: 1rem 0rem;
+        gap: 0.4rem;
         display: flex;
+        justify-content: flex-start;
         align-items: center;
       `}
     >

--- a/src/pages/Studio/StudioReview/components/StudioReviewImageList.tsx
+++ b/src/pages/Studio/StudioReview/components/StudioReviewImageList.tsx
@@ -78,7 +78,7 @@ const DimOverlayStyle = styled.div`
   top: 0;
   left: 0;
   width: 100%;
-  height: calc(100% - 0.3rem);
+  height: calc(100%);
   background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;

--- a/src/store/useFilterStore.ts
+++ b/src/store/useFilterStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface FilterStore {
+  minPrice: string;
+  maxPrice: string;
+  selectedServices: string[];
+  setMinPrice: (price: string) => void;
+  setMaxPrice: (price: string) => void;
+  setSelectedServices: (services: string[]) => void;
+  resetFilter: () => void;
+}
+
+export const useFilterStore = create<FilterStore>((set) => ({
+  minPrice: '',
+  maxPrice: '',
+  selectedServices: [],
+  setMinPrice: (price) => set({ minPrice: price }),
+  setMaxPrice: (price) => set({ maxPrice: price }),
+  setSelectedServices: (services) => set({ selectedServices: services }),
+  resetFilter: () => set({ minPrice: '', maxPrice: '', selectedServices: [] }),
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #475


<br>

## 📝 작업 내용
> PC에서 가격 섹션 부분 기능 변경으로 인한 분리 
- 모바일에서는 각자 초기화나 적용하기 기능이 있지만 PC에서는 일괄로 처리함 
- 선택된 요소를 useFIlterStore를 통해 선택된 요소 저장 후 URL를 통해 값이 변경 되도록 구현
- HOME에 있던 요소를 PCFIlterWrapper로 분리 

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
