### PR TITLE
[WEB2] PC 버전 토스트 구현

### DIFF
--- a/src/components/ReservationFooter/ReservationFooter.tsx
+++ b/src/components/ReservationFooter/ReservationFooter.tsx
@@ -29,7 +29,7 @@ const ReservationFooter = ({
 
       <Button
         text={text}
-        variant="deepGray"
+        variant="gray"
         active={!disabled}
         type={type}
         onClick={onClick}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
 import { useToastStore } from '@store/useToastStore';
+import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { TypoBodyMdM } from '@styles/Common';
 import variables from '@styles/Variables';
 import { createPortal } from 'react-dom';
@@ -34,6 +35,13 @@ const ToastContainerStyle = styled.div`
   right: ${variables.layoutPadding};
   bottom: 4.4rem;
   z-index: 9999;
+
+  ${mqMin(breakPoints.pc)} {
+    left: unset;
+    right: 4rem;
+    bottom: 4rem;
+    width: 32.8rem;
+  }
 `;
 
 const ToastStyle = styled.div`
@@ -50,6 +58,11 @@ const ToastStyle = styled.div`
     fadeIn 0.3s ease forwards,
     slideOut 0.3s ease forwards 2.7s,
     fadeOut 0.3s ease forwards 2.7s;
+
+  ${mqMin(breakPoints.pc)} {
+    width: 100%;
+    padding: 1.2rem 1.6rem;
+  }
 
   @keyframes slideIn {
     from {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -51,9 +51,15 @@ const Home = () => {
   const navigate = useNavigate();
   const windowWidth = useGetWindowWidth();
 
-  // 로그인 완료 후 예약페이지로 돌아가기
-  const lastPage = window.sessionStorage.getItem('lastPage');
-  if (lastPage) navigate(lastPage);
+  useEffect(() => {
+    // 로그인 완료 후 예약페이지로 돌아가기
+    const lastPage = window.sessionStorage.getItem('lastPage');
+
+    if (lastPage) {
+      navigate(lastPage);
+      window.sessionStorage.removeItem('lastPage');
+    }
+  }, []);
 
   // 스크롤에 따라 Navigator 고정
   useEffect(() => {

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -14,6 +14,7 @@ import useReservationStore from '@store/useReservationStore';
 import { Helmet } from 'react-helmet-async';
 import { defaultUserState } from '@store/useUserStore';
 import { getLocalStorageItem } from '@utils/getLocalStorageItem';
+import useToast from '@hooks/useToast';
 
 const StudioMenuDetail = () => {
   const { _menuId, _id } = useParams();
@@ -26,6 +27,7 @@ const StudioMenuDetail = () => {
   const { totalPrice, options, menuId } = useReservationStore();
   const { accessToken: user } = getLocalStorageItem<IUser>('userState', defaultUserState);
   const { pathname } = useLocation();
+  const openToast = useToast();
 
   const fetchMenuDetail = async () => {
     const res = await fetch(`${import.meta.env.VITE_TOUCHEESE_API}/studio/detail/menu/${_menuId}`, {
@@ -82,9 +84,9 @@ const StudioMenuDetail = () => {
     saveReservationDetails(saveData);
 
     if (user) {
-      window.sessionStorage.removeItem('lastPage');
       navigate(`/studio/${_id}/reservation`);
     } else {
+      openToast('로그인이 필요합니다!');
       window.sessionStorage.setItem('lastPage', pathname);
       navigate('/user/auth');
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#525 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- PC 버전 토스트 구현
- 메뉴 상세에서 로그인 하지 않은 상태로 예약하기를 눌렀을 때 => 로그인 => 메뉴로 돌아가는데, 이 때 홈화면으로 이동할 때마다 다시 메뉴 상세로 튕겨나가는 버그 해결

1. 로그인 안 된 상태로 예약하기를 누르면
    `1-1. 로그인 페이지로 보낸다.`
    `1-2. 세션스토리지에 lastPage를 저장한다.`

2. 로그인하고 홈으로 라우팅되면
    `2-1. lastPage가 있으면 해당 주소로 라우팅한다.`
    `2-2. 세션스토리지에서 lastPage를 삭제한다.`

**=> 홈에서 라우팅 시킬 때 세션스토리지에서 `lastPage` 삭제**

<br>

## 💬 리뷰 요구사항(선택)

@kyungmim 임시로 로직 바꿔두었으니 수정하세요~
