### PR TITLE
[WEB3] 예약 스케줄 페이지 반응형 구현

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -8,6 +8,7 @@ import variables from '@styles/Variables';
 import { useEffect, useState } from 'react';
 import createCalendar from './createCalendar';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
 
 interface CalendarProp {
   type?: string;
@@ -31,6 +32,7 @@ const Calendar = ({ type = 'filter', disableDates }: CalendarProp) => {
   const baseYear = baseDate.getFullYear();
   const baseMonth = baseDate.getMonth();
   const today = new Date();
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
 
   const resetTime = () => setTime('reset');
 
@@ -110,13 +112,11 @@ const Calendar = ({ type = 'filter', disableDates }: CalendarProp) => {
       </TopStyle>
       <CalendarStyle>
         <DayOfWeekStyle>
-          <li>일</li>
-          <li>월</li>
-          <li>화</li>
-          <li>수</li>
-          <li>목</li>
-          <li>금</li>
-          <li>토</li>
+          {week.map((day) => (
+            <li key={day} css={calendarRatio(type)}>
+              {day}
+            </li>
+          ))}
         </DayOfWeekStyle>
         <ul
           onTouchStart={(e) => setStartClientX(e.touches[0].clientX)}
@@ -137,10 +137,15 @@ const Calendar = ({ type = 'filter', disableDates }: CalendarProp) => {
                     ${isNextMonth && nextMonthStyle};
                     ${isPrevToday && disabledStyle}
                     ${isReservationComplete && disabledStyle}
+                    ${calendarRatio(type)}
                   `}
                   key={`${month} - ${date}`}
                 >
-                  <button type="button" onClick={() => handleDateClick(year, month, date)}>
+                  <button
+                    type="button"
+                    css={calendarRatio(type)}
+                    onClick={() => handleDateClick(year, month, date)}
+                  >
                     {date}
                     <span css={Hidden}>일</span>
                   </button>
@@ -158,16 +163,30 @@ const Calendar = ({ type = 'filter', disableDates }: CalendarProp) => {
 
 export default Calendar;
 
+const calendarRatio = (type: string) => css`
+  ${mqMax(breakPoints.moMax)} {
+    aspect-ratio: 1/1;
+  }
+  ${mqMin(breakPoints.pc)} {
+    aspect-ratio: ${type === 'reservation' ? '88/53' : '1/1'};
+  }
+`;
+
 const CalendarWrStyle = styled.article`
-  max-width: 500px;
+  max-width: 620px;
   width: 100%;
   margin: 0 auto 1rem;
+
+  ${mqMin(breakPoints.pc)} {
+    margin: 1.6rem auto 2rem;
+  }
 `;
 
 const TopStyle = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
+  margin-bottom: 0.4rem;
 `;
 
 const TodayStyle = styled.button`
@@ -190,7 +209,6 @@ const TitleStyle = styled.div`
 
   button {
     width: 2.4rem;
-    aspect-ratio: 1/1;
     background: url(/img/icon-chevronright.svg) no-repeat center;
   }
 `;
@@ -202,7 +220,6 @@ const CalendarStyle = styled.div`
     font-size: 1.6rem;
 
     li {
-      aspect-ratio: 1/1;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -210,7 +227,6 @@ const CalendarStyle = styled.div`
 
       button {
         width: 100%;
-        aspect-ratio: 1 / 1;
         text-align: center;
       }
     }

--- a/src/components/ReservationFooter/ReservationFooter.tsx
+++ b/src/components/ReservationFooter/ReservationFooter.tsx
@@ -42,6 +42,19 @@ const ReservationFooter = ({
 
 export default ReservationFooter;
 
+export const reservationFooterWrStyle = css`
+  ${mqMin(breakPoints.pc)} {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: calc(100vh - ${variables.headerHeight});
+
+    .content-box {
+      overflow: hidden auto;
+    }
+  }
+`;
+
 const FixedBtnBoxStyle = css`
   display: flex;
   gap: 2rem;
@@ -71,9 +84,6 @@ const FixedBtnBoxStyle = css`
     }
   }
   ${mqMin(breakPoints.pc)} {
-    width: calc(100vw - (509px + 35px));
-    left: auto;
-    right: 0;
-    padding: 1.8rem 2.4rem 3rem;
+    position: inherit;
   }
 `;

--- a/src/pages/Home/components/SelectTime.tsx
+++ b/src/pages/Home/components/SelectTime.tsx
@@ -7,6 +7,7 @@ import { filterTimes } from '@hooks/useGetAvailableDate';
 import useToast from '@hooks/useToast';
 import { convertToDateFormat, today, useSelectDateStore } from '@store/useSelectDateStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { DividerStyle, Hidden, TypoBodyMdM, TypoBodySmR } from '@styles/Common';
 import variables from '@styles/Variables';
 import { useMemo } from 'react';
@@ -70,7 +71,7 @@ const SelectTime = ({ type, availableTimeWithDates }: ITimeProp) => {
 
   return (
     <>
-      <section css={[SelectTimeStyle, DividerStyle]}>
+      <section css={[SelectTimeStyle(type), DividerStyle]}>
         <h2 css={Hidden}>시간 선택</h2>
 
         <div css={articleBox}>
@@ -138,8 +139,14 @@ const SelectTime = ({ type, availableTimeWithDates }: ITimeProp) => {
 
 export default SelectTime;
 
-const SelectTimeStyle = css`
+const SelectTimeStyle = (type: string) => css`
   padding-top: 3rem;
+  ${mqMin(breakPoints.pc)} {
+    padding-top: ${type === 'reservation' && '4.6rem'};
+    &::after {
+      width: ${type === 'reservation' && 'calc(100% + 9.6rem) !important'};
+    }
+  }
 
   &::after {
     bottom: auto;

--- a/src/pages/Reservation/ReservationCheck.tsx
+++ b/src/pages/Reservation/ReservationCheck.tsx
@@ -19,8 +19,9 @@ import { useForm } from 'react-hook-form';
 import Payment from './components/Payment';
 import useReservationStore from '@store/useReservationStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
-import { changeformatDateForUi, useSelectDateStore } from '@store/useSelectDateStore';
+import { useSelectDateStore } from '@store/useSelectDateStore';
 import { useUserStore } from '@store/useUserStore';
+import ReservationInfo from './components/ReservationInfo';
 
 interface FormValues {
   visitorName: string;
@@ -39,7 +40,7 @@ const ReservationCheck = () => {
 
   const { time } = useSelectTimeStore();
   const { date } = useSelectDateStore();
-  const { studioName, totalPrice, options, menuName, basicPrice, menuImage, menuId, requests } =
+  const { totalPrice, options, menuName, basicPrice, menuImage, menuId, requests } =
     useReservationStore();
   const { username, phone, user_id } = useUserStore();
   const [isDifferentVisitor, setIsDifferentVisitor] = useState(false);
@@ -118,36 +119,11 @@ const ReservationCheck = () => {
       <Header title="결제하기" />
 
       {/* 예약정보 */}
-      <section css={paddingTopStyle}>
-        <h2 css={[TypoTitleXsSb, titleAlignStyle, firstTitleAlignStyle]}>예약정보</h2>
-        <div css={boxStyle}>
-          <h4
-            css={css`
-              color: ${variables.colors.gray800};
-              font-size: 1.2rem;
-            `}
-          >
-            {studioName}
-          </h4>
-          <p css={TypoTitleXsM}>{changeformatDateForUi({ date, time })}</p>
-          <hr css={hrStyle} />
-          <div css={flexRow}>
-            <div>
-              <p css={TypoTitleXsM}>{menuName}</p>
-              <div css={textWrapperStyle}>
-                {options.map((option) => (
-                  <span key={option.option_id}>{option.optionName}</span>
-                ))}
-              </div>
-            </div>
-            <img src={menuImage} alt="포트폴리오 이미지" css={imgStyle} />
-          </div>
-        </div>
-      </section>
+      <ReservationInfo />
 
       {/* 예약자정보 */}
       <section>
-        <h2 css={[TypoTitleXsSb, titleAlignStyle]}>예약자정보</h2>
+        <h2 css={reservationTitleAlignStyle}>예약자정보</h2>
         <p css={TypoTitleXsM}>{username}</p>
         <p css={TypoTitleXsM}>{phone}</p>
         <div css={checkboxWrapperStyle}>
@@ -217,7 +193,7 @@ const ReservationCheck = () => {
           </section>
         )}
         <section>
-          <h2 css={[TypoTitleXsSb, titleAlignStyle]}>요청사항</h2>
+          <h2 css={reservationTitleAlignStyle}>요청사항</h2>
           <div css={textareaBox}>
             <textarea
               css={textRequestsStyle}
@@ -232,8 +208,8 @@ const ReservationCheck = () => {
 
       {/* 결제정보*/}
       <section css={paymentSectionStyle}>
-        <h2 css={[TypoTitleXsSb, titleAlignStyle]}>결제정보</h2>
-        <div css={[boxStyle, TypoBodySmR]}>
+        <h2 css={reservationTitleAlignStyle}>결제정보</h2>
+        <div css={[reservationBoxStyle, TypoBodySmR]}>
           <div css={[PriceInforowStyle, options.length > 0 && basicPriceStyle]}>
             <span>기본 가격</span>
             <span>{menuName}</span>
@@ -260,7 +236,7 @@ const ReservationCheck = () => {
             </div>
           )}
 
-          <hr css={hrStyle} />
+          <hr css={reservationHrStyle} />
           <div css={[PriceInforowStyle, TypoTitleXsSb, totalPriceStyle]}>
             <span>총 결제금액</span>
             <span>{totalPrice.toLocaleString()}원</span>
@@ -270,7 +246,7 @@ const ReservationCheck = () => {
 
       {/* 결제수단 */}
       <section>
-        <h2 css={[TypoTitleXsSb, titleAlignStyle]}>결제수단</h2>
+        <h2 css={reservationTitleAlignStyle}>결제수단</h2>
         <div css={[TypoTitleXsR, radioGroupStyle]}>
           <li css={radioLabelStyle}>
             <input
@@ -344,7 +320,7 @@ const ReservationCheck = () => {
               <span>이용 7일 전까지</span>
               <span>결제 금액에 대한 취소 수수료 없음</span>
             </div>
-            <hr css={hrStyle} />
+            <hr css={reservationHrStyle} />
             <div css={refundInfoRowStyle}>
               <span>이용 7일 전 ~ 이용 당일</span>
               <span>취소 불가</span>
@@ -377,61 +353,25 @@ const ReservationCheck = () => {
 
 export default ReservationCheck;
 
-const paddingTopStyle = css`
-  padding-top: ${variables.headerHeight};
-`;
-
-const titleAlignStyle = css`
+export const reservationTitleAlignStyle = css`
   height: 4.2rem;
   line-height: 4.2rem;
   margin-top: 0.4rem;
+  ${TypoTitleXsSb}
 `;
 
-const firstTitleAlignStyle = css`
-  margin-top: 0;
-`;
-
-const boxStyle = css`
+export const reservationBoxStyle = css`
   border: 1px solid ${variables.colors.gray400};
   border-radius: 0.6rem;
   padding: 1rem 1.4rem;
 `;
 
-const hrStyle = css`
+export const reservationHrStyle = css`
   border: none;
   border-bottom: 0.1rem solid ${variables.colors.gray400};
 `;
 
-//예약정보
-const flexRow = css`
-  display: flex;
-`;
-
-const imgStyle = css`
-  width: 6rem;
-  height: 7.2rem;
-  margin-left: auto;
-  object-fit: cover;
-`;
-
-const textWrapperStyle = css`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin-top: 0.5rem;
-  span {
-    position: relative;
-    color: ${variables.colors.gray900};
-    font-size: 1.2rem;
-  }
-  span:not(:last-child)::after {
-    content: '|';
-    margin-left: 0.6rem;
-    color: #ccc;
-  }
-`;
-
-//예약자정보
+// 예약자정보
 const checkboxWrapperStyle = css`
   width: 13rem;
   height: 3rem;

--- a/src/pages/Reservation/ReservationCheck.tsx
+++ b/src/pages/Reservation/ReservationCheck.tsx
@@ -22,6 +22,7 @@ import { useSelectTimeStore } from '@store/useSelectTimeStore';
 import { useSelectDateStore } from '@store/useSelectDateStore';
 import { useUserStore } from '@store/useUserStore';
 import ReservationInfo from './components/ReservationInfo';
+import { breakPoints, mqMin } from '@styles/BreakPoint';
 
 interface FormValues {
   visitorName: string;
@@ -364,11 +365,20 @@ export const reservationBoxStyle = css`
   border: 1px solid ${variables.colors.gray400};
   border-radius: 0.6rem;
   padding: 1rem 1.4rem;
+
+  ${mqMin(breakPoints.pc)} {
+    padding: 1.4rem 1.6rem;
+  }
 `;
 
 export const reservationHrStyle = css`
   border: none;
   border-bottom: 0.1rem solid ${variables.colors.gray400};
+  margin: 1rem 0;
+
+  ${mqMin(breakPoints.pc)} {
+    margin: 1.5rem 0;
+  }
 `;
 
 // 예약자정보

--- a/src/pages/Reservation/ReservationSchedule.tsx
+++ b/src/pages/Reservation/ReservationSchedule.tsx
@@ -1,12 +1,17 @@
 /** @jsxImportSource @emotion/react */
 
 import Header from '@components/Header/Header';
+import { css } from '@emotion/react';
 import { convertToDateFormat, today, useSelectDateStore } from '@store/useSelectDateStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
+import variables from '@styles/Variables';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
+import ReservationInfo from './components/ReservationInfo';
 import ScheduleInner from './components/ScheduleInner';
+import { reservationFooterWrStyle } from '@components/ReservationFooter/ReservationFooter';
 
 const ReservationSchedule = () => {
   const { _id } = useParams() as { _id: string };
@@ -29,9 +34,47 @@ const ReservationSchedule = () => {
       </Helmet>
 
       <Header title="예약하기" />
-      <ScheduleInner _id={_id} />
+
+      <div css={[pcFlexLayout, scheduleLayout]}>
+        <div className="left-box">
+          <ReservationInfo />
+        </div>
+        <div className="right-box" css={reservationFooterWrStyle}>
+          <ScheduleInner _id={_id} />
+        </div>
+      </div>
     </>
   );
 };
 
 export default ReservationSchedule;
+
+export const pcFlexLayout = css`
+  ${mqMin(breakPoints.pc)} {
+    display: flex;
+    gap: 3.5rem;
+    align-content: flex-start;
+
+    .left-box {
+      padding-top: ${variables.headerBottomPadding};
+      width: 40%;
+      max-width: 50.4rem;
+    }
+    .right-box {
+      flex-grow: 1;
+      overflow: hidden;
+
+      .content-box {
+        padding: ${variables.headerBottomPadding} ${variables.layoutPadding} 8rem;
+      }
+    }
+  }
+`;
+
+const scheduleLayout = css`
+  ${mqMax(breakPoints.moMax)} {
+    .left-box {
+      display: none;
+    }
+  }
+`;

--- a/src/pages/Reservation/components/ReservationInfo.tsx
+++ b/src/pages/Reservation/components/ReservationInfo.tsx
@@ -4,13 +4,14 @@ import { css } from '@emotion/react';
 import useReservationStore from '@store/useReservationStore';
 import { changeformatDateForUi, useSelectDateStore } from '@store/useSelectDateStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
-import { TypoTitleXsM } from '@styles/Common';
+import { TypoBodySmR, TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
 import {
   reservationBoxStyle,
   reservationHrStyle,
   reservationTitleAlignStyle,
 } from '../ReservationCheck';
+import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
 
 const ReservationInfo = () => {
   const { studioName, options, menuName, menuImage } = useReservationStore();
@@ -18,41 +19,56 @@ const ReservationInfo = () => {
   const { date } = useSelectDateStore();
 
   return (
-    <>
-      <section css={paddingTopStyle}>
-        <h2 css={[reservationTitleAlignStyle, firstTitleAlignStyle]}>예약정보</h2>
-        <div css={reservationBoxStyle}>
-          <h4
-            css={css`
-              color: ${variables.colors.gray800};
-              font-size: 1.2rem;
-            `}
-          >
-            {studioName}
-          </h4>
-          <p css={TypoTitleXsM}>{changeformatDateForUi({ date, time })}</p>
-          <hr css={reservationHrStyle} />
-          <div css={flexRow}>
-            <div>
-              <p css={TypoTitleXsM}>{menuName}</p>
-              <div css={textWrapperStyle}>
+    <section css={reservationInfoStyle}>
+      <h2 css={[reservationTitleAlignStyle, firstTitleAlignStyle]}>예약정보</h2>
+
+      <div css={reservationBoxStyle}>
+        <dl>
+          <dt>사진관 이름</dt>
+          <dd>
+            <h3 css={studioNameStyle}>{studioName}</h3>
+          </dd>
+          <dt css={marginTop}>예약 일시</dt>
+          <dd>
+            <h3 css={TypoTitleXsM}>{changeformatDateForUi({ date, time })}</h3>
+          </dd>
+        </dl>
+
+        <hr css={reservationHrStyle} />
+
+        <div css={flexRow}>
+          <dl>
+            <dt>예약 촬영</dt>
+            <dd>
+              <h3 css={TypoTitleXsM}>{menuName}</h3>
+            </dd>
+            <dt css={marginTop}>추가 옵션</dt>
+            <dd>
+              <h3 css={textWrapperStyle}>
                 {options.map((option) => (
                   <span key={option.option_id}>{option.optionName}</span>
                 ))}
-              </div>
-            </div>
-            <img src={menuImage} alt="포트폴리오 이미지" css={imgStyle} />
-          </div>
+              </h3>
+            </dd>
+          </dl>
+          <img src={menuImage} alt="포트폴리오 이미지" css={imgStyle} />
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 };
 
 export default ReservationInfo;
 
-const paddingTopStyle = css`
-  padding-top: ${variables.headerHeight};
+const studioNameStyle = css`
+  ${mqMax(breakPoints.moMax)} {
+    color: ${variables.colors.gray800};
+    font-size: 1.2rem;
+  }
+
+  ${mqMin(breakPoints.pc)} {
+    ${TypoTitleXsM}
+  }
 `;
 
 const firstTitleAlignStyle = css`
@@ -65,9 +81,13 @@ const flexRow = css`
 
 const imgStyle = css`
   width: 6rem;
-  height: 7.2rem;
+  aspect-ratio: 60/72;
   margin-left: auto;
   object-fit: cover;
+
+  ${mqMin(breakPoints.pc)} {
+    width: 14rem;
+  }
 `;
 
 const textWrapperStyle = css`
@@ -78,11 +98,30 @@ const textWrapperStyle = css`
   span {
     position: relative;
     color: ${variables.colors.gray900};
-    font-size: 1.2rem;
+    ${TypoBodySmR}
   }
   span:not(:last-child)::after {
     content: '|';
     margin-left: 0.6rem;
     color: #ccc;
+    font-size: 0.8em;
   }
+`;
+
+const reservationInfoStyle = css`
+  dl {
+    dt {
+      ${TypoBodySmR}
+      color: ${variables.colors.gray700};
+      padding-bottom: 0.2rem;
+
+      ${mqMax(breakPoints.moMax)} {
+        display: none;
+      }
+    }
+  }
+`;
+
+const marginTop = css`
+  margin-top: 0.8rem;
 `;

--- a/src/pages/Reservation/components/ReservationInfo.tsx
+++ b/src/pages/Reservation/components/ReservationInfo.tsx
@@ -1,0 +1,88 @@
+/** @jsxImportSource @emotion/react */
+
+import { css } from '@emotion/react';
+import useReservationStore from '@store/useReservationStore';
+import { changeformatDateForUi, useSelectDateStore } from '@store/useSelectDateStore';
+import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { TypoTitleXsM } from '@styles/Common';
+import variables from '@styles/Variables';
+import {
+  reservationBoxStyle,
+  reservationHrStyle,
+  reservationTitleAlignStyle,
+} from '../ReservationCheck';
+
+const ReservationInfo = () => {
+  const { studioName, options, menuName, menuImage } = useReservationStore();
+  const { time } = useSelectTimeStore();
+  const { date } = useSelectDateStore();
+
+  return (
+    <>
+      <section css={paddingTopStyle}>
+        <h2 css={[reservationTitleAlignStyle, firstTitleAlignStyle]}>예약정보</h2>
+        <div css={reservationBoxStyle}>
+          <h4
+            css={css`
+              color: ${variables.colors.gray800};
+              font-size: 1.2rem;
+            `}
+          >
+            {studioName}
+          </h4>
+          <p css={TypoTitleXsM}>{changeformatDateForUi({ date, time })}</p>
+          <hr css={reservationHrStyle} />
+          <div css={flexRow}>
+            <div>
+              <p css={TypoTitleXsM}>{menuName}</p>
+              <div css={textWrapperStyle}>
+                {options.map((option) => (
+                  <span key={option.option_id}>{option.optionName}</span>
+                ))}
+              </div>
+            </div>
+            <img src={menuImage} alt="포트폴리오 이미지" css={imgStyle} />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default ReservationInfo;
+
+const paddingTopStyle = css`
+  padding-top: ${variables.headerHeight};
+`;
+
+const firstTitleAlignStyle = css`
+  margin-top: 0;
+`;
+
+const flexRow = css`
+  display: flex;
+`;
+
+const imgStyle = css`
+  width: 6rem;
+  height: 7.2rem;
+  margin-left: auto;
+  object-fit: cover;
+`;
+
+const textWrapperStyle = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+  span {
+    position: relative;
+    color: ${variables.colors.gray900};
+    font-size: 1.2rem;
+  }
+  span:not(:last-child)::after {
+    content: '|';
+    margin-left: 0.6rem;
+    color: #ccc;
+  }
+`;

--- a/src/pages/Reservation/components/ScheduleInner.tsx
+++ b/src/pages/Reservation/components/ScheduleInner.tsx
@@ -7,6 +7,7 @@ import { useGetAvailableDate } from '@hooks/useGetAvailableDate';
 import SelectTime from '@pages/Home/components/SelectTime';
 import { getDay, useSelectDateStore } from '@store/useSelectDateStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
 import { Hidden } from '@styles/Common';
 import variables from '@styles/Variables';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -22,7 +23,7 @@ const ScheduleInner = ({ _id }: { _id: string }) => {
 
   return (
     <>
-      <div css={contentBox}>
+      <div className="content-box">
         <Calendar type="reservation" disableDates={availableDate?.disableDates} />
         <SelectTime
           type="reservation"
@@ -55,17 +56,15 @@ const ScheduleInner = ({ _id }: { _id: string }) => {
 
 export default ScheduleInner;
 
-const contentBox = css`
-  padding-bottom: 8rem;
-`;
-
 const fixedBox = css`
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border-top: 1px solid ${variables.colors.gray300};
-  background: #fff;
+  ${mqMax(breakPoints.moMax)} {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-top: 1px solid ${variables.colors.gray300};
+    background: #fff;
+  }
 `;
 
 const finalDate = css`
@@ -73,6 +72,10 @@ const finalDate = css`
   display: flex;
   gap: 1.4rem;
   align-items: center;
+
+  ${mqMin(breakPoints.pc)} {
+    display: none;
+  }
 
   // ReservationFooter
   & + div {

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import Header from '@components/Header/Header';
-import ReservationFooter from '@components/ReservationFooter/ReservationFooter';
+import ReservationFooter, {
+  reservationFooterWrStyle,
+} from '@components/ReservationFooter/ReservationFooter';
 import ImageSwiper from '@components/Swiper/ImageSwiper';
 import { css } from '@emotion/react';
 import useToast from '@hooks/useToast';
@@ -131,33 +133,35 @@ const StudioMenuDetail = () => {
           </div>
         )}
 
-        <div css={MenuInfoPCStyle}>
-          <div css={MenuDescStyle}>
-            <h2>{data?.name}</h2>
-            <p>{data?.description}</p>
+        <div css={reservationFooterWrStyle}>
+          <div css={MenuInfoPCStyle} className="contentBox">
+            <div css={MenuDescStyle}>
+              <h2>{data?.name}</h2>
+              <p>{data?.description}</p>
+            </div>
+            <ul css={TabMenuStyle}>
+              <li
+                onClick={() => setTabMenuState('info')}
+                className={`${tabMenuState === 'info' && 'active'}`}
+              >
+                정보
+              </li>
+              <li
+                onClick={() => setTabMenuState('review')}
+                className={`${tabMenuState === 'review' && 'active'}`}
+              >
+                리뷰 {data?.reviewCount ? data?.reviewCount : '0'}
+              </li>
+            </ul>
+            {data && tabMenuState === 'info' && <StudioMenuDetailInfo infoItem={data} />}
+            {data && tabMenuState === 'review' && (
+              <StudioMenuDetailReview reviewItem={data?.reviews.content} rating={data?.avgScore} />
+            )}
           </div>
 
-          <ul css={TabMenuStyle}>
-            <li
-              onClick={() => setTabMenuState('info')}
-              className={`${tabMenuState === 'info' && 'active'}`}
-            >
-              정보
-            </li>
-            <li
-              onClick={() => setTabMenuState('review')}
-              className={`${tabMenuState === 'review' && 'active'}`}
-            >
-              리뷰 {data?.reviewCount ? data?.reviewCount : '0'}
-            </li>
-          </ul>
-          {data && tabMenuState === 'info' && <StudioMenuDetailInfo infoItem={data} />}
-          {data && tabMenuState === 'review' && (
-            <StudioMenuDetailReview reviewItem={data?.reviews.content} rating={data?.avgScore} />
-          )}
+          <ReservationFooter text="예약하기" type="button" onClick={handleReservartionNext} />
         </div>
       </div>
-      <ReservationFooter text="예약하기" type="button" onClick={handleReservartionNext} />
     </>
   );
 };

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -34,8 +34,6 @@ const StudioMenuDetail = () => {
   const { accessToken: user } = getLocalStorageItem<IUser>('userState', defaultUserState);
   const { pathname } = useLocation();
   const openToast = useToast();
-  const isMobile = useIsMobile();
-  const scheduleModal = useModal();
 
   const fetchMenuDetail = async () => {
     const res = await fetch(`${import.meta.env.VITE_TOUCHEESE_API}/studio/detail/menu/${_menuId}`, {
@@ -92,8 +90,7 @@ const StudioMenuDetail = () => {
     saveReservationDetails(saveData);
 
     if (user) {
-      if (isMobile) navigate(`/studio/${_id}/reservation`);
-      else scheduleModal.open();
+      navigate(`/studio/${_id}/reservation`);
     } else {
       openToast('로그인이 필요합니다!');
       window.sessionStorage.setItem('lastPage', pathname);
@@ -165,10 +162,6 @@ const StudioMenuDetail = () => {
         </div>
       </div>
       <ReservationFooter text="예약하기" type="button" onClick={handleReservartionNext} />
-
-      <Modal modalId={1} type="fullscreen" title="예약하기">
-        <ScheduleInner _id={_id!} />
-      </Modal>
     </>
   );
 };

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -1,13 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import Header from '@components/Header/Header';
-import Modal from '@components/Modal/Modal';
 import ReservationFooter from '@components/ReservationFooter/ReservationFooter';
 import ImageSwiper from '@components/Swiper/ImageSwiper';
 import { css } from '@emotion/react';
-import useIsMobile from '@hooks/useIsMobile';
-import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
-import ScheduleInner from '@pages/Reservation/components/ScheduleInner';
 import useReservationStore from '@store/useReservationStore';
 import { defaultUserState } from '@store/useUserStore';
 import { breakPoints, mqMin } from '@styles/BreakPoint';

--- a/src/styles/Variables.tsx
+++ b/src/styles/Variables.tsx
@@ -44,6 +44,7 @@ const variables = {
   borderRadius: '.8rem',
   borderRadiusLarge: '2rem',
   headerHeight: 'var(--headerHeight)',
+  headerBottomPadding: '3rem',
   maxWidth: 'var(--maxWidth)',
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#577 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 공통
- headerBottomPadding 변수 추가

### 예약 정보
- 예약정보 컴포넌트로 분리
- 예약정보 반응형 구현

### 예약 레이아웃
- Style: 예약 PC 레이아웃 설정
- Style: 예약 PC 레이아웃 적용 - 스케줄
- Style: 예약 PC 레이아웃 적용 - 메뉴 상세

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


@aksenmi 지민님! `ReservationSchedule.tsx` 파일 참고하셔서 예약 레이아웃 반영 부탁드립니다 !
@kyungmim 경민님! `ReservationFooter`, `StudioMenuDetail` 파일 수정했으니 참고 부탁드립니다.