### PR TITLE
[WEB3] 유저 정보 및 계정 정보 변경 기능을 구현한다.

### DIFF
--- a/src/pages/User/ChangePassword.tsx
+++ b/src/pages/User/ChangePassword.tsx
@@ -4,6 +4,7 @@ import BackButton from '@components/BackButton/BackButton';
 import Button from '@components/Button/Button';
 import Input from '@components/Input/Input';
 import { css } from '@emotion/react';
+import useToast from '@hooks/useToast';
 import { TypoTitleXsM } from '@styles/Common';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -13,7 +14,6 @@ import { useNavigate } from 'react-router-dom';
 const ChangePassword = () => {
   const {
     register,
-    handleSubmit,
     formState: { errors },
     watch,
   } = useForm();
@@ -21,6 +21,7 @@ const ChangePassword = () => {
   const [isActive, setIsActive] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
   const navigate = useNavigate();
+  const openToast = useToast();
 
   const email = watch('email');
   const newPassword = watch('newPassword');
@@ -39,10 +40,6 @@ const ChangePassword = () => {
     setIsDisabled(!isFormValid);
   }, [email, newPassword, passwordConfirm]);
 
-  const onSubmit = (data: any) => {
-    console.log('onsubmit :', data);
-  };
-
   const loadSessionStorageData = (key: string) => {
     /** key에 해당하는 데이터 호출 */
     const localData = localStorage.getItem(key);
@@ -55,6 +52,7 @@ const ChangePassword = () => {
       return parsedData;
     } catch (error) {
       console.error('JSON 파싱 오류', error);
+      openToast('데이터를 불러오는 데 문제가 발생했습니다.');
       return null;
     }
   };
@@ -67,6 +65,7 @@ const ChangePassword = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({ newPassword }),
       });
@@ -74,10 +73,11 @@ const ChangePassword = () => {
       if (!response.ok) {
         throw new Error(`서버 오류: ${response.status}`);
       }
-      console.log('모달이 열려야함!');
       navigate('/');
+      openToast('비밀번호 변경을 완료했습니다.');
     } catch (error) {
       console.error('비밀번호 변경 중 오류 발생:', error);
+      openToast('비밀번호 변경 중 오류가 발생했습니다');
     }
   };
 
@@ -94,14 +94,11 @@ const ChangePassword = () => {
       return parsedData;
     } catch (error) {
       console.error('JSON 파싱 오류', error);
+      openToast('서버 응답을 처리하는 데 문제가 발생했습니다.');
       return null;
     }
   };
   const emailData = loadLocalStorageData('userState');
-
-  console.log('보낼 데이터:', { newPassword });
-  console.log('요청 URL:', `${import.meta.env.VITE_TOUCHEESE_API}/user/mypage/changepw`);
-  console.log('Authorization 헤더:', `Bearer ${accessToken}`);
 
   return (
     <>
@@ -117,7 +114,7 @@ const ChangePassword = () => {
         <h1>비밀번호 변경</h1>
       </div>
 
-      <form noValidate css={formStyle} onSubmit={handleSubmit(onSubmit)}>
+      <form noValidate css={formStyle}>
         <div css={containerStyle}>
           {/* 비밀번호 */}
           <Input
@@ -165,8 +162,8 @@ const ChangePassword = () => {
         <div css={buttonStyle}>
           <Button
             onClick={handleVerifyComplete}
-            type="submit"
-            text="가입하기"
+            type="button"
+            text="변경하기"
             size="large"
             variant="gray"
             width="max"

--- a/src/pages/User/ChangeProfile.tsx
+++ b/src/pages/User/ChangeProfile.tsx
@@ -4,6 +4,7 @@ import BackButton from '@components/BackButton/BackButton';
 import Button from '@components/Button/Button';
 import Input from '@components/Input/Input';
 import { css } from '@emotion/react';
+import useToast from '@hooks/useToast';
 import useSignupStore from '@store/useSignupStore';
 import { TypoTitleXsM, TypoTitleXsSb } from '@styles/Common';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
@@ -37,25 +38,23 @@ const ChangeProfile = () => {
   const storageName = parsedData?.state?.username || '';
   const storagePhone = parsedData?.state?.phone || '';
 
-  // const [username, setUsername] = useState('');
-  // const [phone, setPhone] = useState('');
-  // const [loading, setLoading] = useState(false);
+  const [username] = useState('');
+  const [phone] = useState('');
+  const openToast = useToast();
 
   const handleEditProfile = async () => {
-    // setLoading(true);
-    // try {
-    //   const response = await fetch('/api/user/profile', {
-    //     method: 'PATCH',
-    //     headers: { 'Content-Type': 'application/json' },
-    //     body: JSON.stringify({ username, phone }),
-    //   });
-    //   if (!response.ok) throw new Error('업데이트 실패');
-    //   console.log('회원정보 수정 성공!');
-    // } catch (error) {
-    //   console.error('회원정보 수정 오류:', error);
-    // } finally {
-    //   setLoading(false);
-    // }
+    try {
+      const response = await fetch(`${import.meta.env.VITE_TOUCHEESE_API}/user/mypage/changeph`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, phone }),
+      });
+      if (!response.ok) throw new Error('업데이트 실패');
+      openToast('회원 정보 수정이 완료 되었습니다.');
+    } catch (error) {
+      console.error('회원정보 수정 오류:', error);
+      openToast('알수없는 오류가 발생했습니다.');
+    }
   };
 
   const {

--- a/src/pages/User/PasswordConfirm.tsx
+++ b/src/pages/User/PasswordConfirm.tsx
@@ -3,6 +3,7 @@ import BackButton from '@components/BackButton/BackButton';
 import Button from '@components/Button/Button';
 import Input from '@components/Input/Input';
 import { css } from '@emotion/react';
+import useToast from '@hooks/useToast';
 import { TypoTitleXsM, TypoTitleXsSb } from '@styles/Common';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -13,10 +14,10 @@ const PasswordConfirm = () => {
   const [isActive, setIsActive] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
   const navigate = useNavigate();
+  const openToast = useToast();
 
   const {
     register,
-    handleSubmit,
     formState: { errors },
     watch,
   } = useForm();
@@ -66,11 +67,8 @@ const PasswordConfirm = () => {
       navigate('/user/profile/passwordChange');
     } catch (error) {
       console.error('비밀번호 확인 중 오류 발생:', error);
+      openToast('비밀번호 확인 중 오류가 발생했습니다.');
     }
-  };
-
-  const onSubmit = (data: any) => {
-    console.log('onsubmit : 데이터 확인용', data);
   };
 
   return (
@@ -91,7 +89,7 @@ const PasswordConfirm = () => {
         <br />
         비밀번호를 다시 한 번 입력해주세요
       </h2>
-      <form noValidate css={formStyle} onSubmit={handleSubmit(onSubmit)}>
+      <form noValidate css={formStyle}>
         <div css={containerStyle}>
           {/* 비밀번호 */}
           <Input

--- a/src/pages/User/Profile.tsx
+++ b/src/pages/User/Profile.tsx
@@ -1,22 +1,22 @@
 /** @jsxImportSource @emotion/react */
 import BackButton from '@components/BackButton/BackButton';
 import Button from '@components/Button/Button';
-import Modal from '@components/Modal/Modal';
 import { css } from '@emotion/react';
-import { useModalStore } from '@store/useModalStore';
+import useToast from '@hooks/useToast';
 import { useUserStore } from '@store/useUserStore';
 import { TypoBodyMdR, TypoTitleXsB, TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const Profile = () => {
   const data = localStorage.getItem('userState');
-  // const openToast = useToast();
-
   const [searchParams] = useSearchParams();
-
   const navigate = useNavigate();
+  const openToast = useToast();
+  const hasShownToastRef = useRef(false);
+
+  const logout = useUserStore((state) => state.resetUser);
 
   const handleProfileEditPage = () => {
     navigate('/user/profile/edit');
@@ -26,51 +26,20 @@ const Profile = () => {
     navigate('/user/profile/passwordConfirm');
   };
 
-  const logout = useUserStore((state) => state.resetUser);
   const handleLogout = () => {
     logout();
     navigate('/');
   };
 
-  const modals = useModalStore((state) => state.modals);
-  const setOpen = useModalStore((state) => state.setOpen);
-
-  const modalId = 1;
-
-  const openModal = () => {
-    setOpen(modalId, true);
-  };
-
-  const closeModal = () => {
-    setOpen(modalId, false);
-  };
-
   useEffect(() => {
-    if (searchParams.get('success') === 'true') {
-      openModal();
+    if (searchParams.get('success') === 'true' && !hasShownToastRef.current) {
+      openToast('개인정보 변경에 성공했습니다.');
+      hasShownToastRef.current = true;
     }
   }, [searchParams]);
 
   return (
     <>
-      {/* 모달 렌더링 */}
-      {modals[modalId] && (
-        <div className="modal_Test">
-          <Modal type="default" title="개인정보가 성공적으로 변경되었어요" withBtn={false}>
-            <Button
-              text="확인"
-              size="medium"
-              width="fit"
-              type="button"
-              variant="black"
-              fixed={false}
-              style={ButtonStyle}
-              onClick={closeModal}
-            />
-          </Modal>
-        </div>
-      )}
-
       <div css={headerStyle}>
         <BackButton />
         <h1>내정보 관리</h1>
@@ -222,10 +191,10 @@ const accoutStyle = css`
   transform: translateX(-50%);
 `;
 
-const ButtonStyle = css`
-  padding: 0 4.6rem;
-  margin: auto;
-  margin-top: 2.8rem;
-`;
+// const ButtonStyle = css`
+//   padding: 0 4.6rem;
+//   margin: auto;
+//   margin-top: 2.8rem;
+// `;
 
 export default Profile;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #477 


<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 비밀번호 및 유저 정보 변경 API 통신 구현 완료
- 비밀번호 및 유저 정보 변경 에러 발생시 Toast 출력
- 비밀번호 및 유저 정보 변경시 불필요한 핸들러 삭제
- 정보 변경 완료시 modal 출력 -> toast 출력으로 변경
- toast 중복 출력으로 인한 useRef 플래그 적용

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
