### PR TITLE
[WEB2] 스튜디오 상세 오른쪽 고정 영역의 너비 및 내부 스타일 수정

### DIFF
--- a/src/components/Header/PCHeader.tsx
+++ b/src/components/Header/PCHeader.tsx
@@ -42,7 +42,7 @@ const HeaderStyle = css`
     top: 0;
     left: 0;
     right: 0;
-    z-index: 9;
+    z-index: 99;
     background-color: ${variables.colors.white};
     box-shadow: inset 0 -0.1rem ${variables.colors.gray300};
     box-sizing: border-box;

--- a/src/components/Studio/StudioInfo.tsx
+++ b/src/components/Studio/StudioInfo.tsx
@@ -6,7 +6,6 @@ import { breakPoints, mqMin } from '@styles/BreakPoint';
 import {
   DividerStyle,
   TypoBodyMdR,
-  TypoBodyMdSb,
   TypoBodySmR,
   TypoTitleMdSb,
   TypoTitleXsR,
@@ -34,6 +33,7 @@ const StudioInfo = ({ data, id }: IStudioInfo) => {
           position: sticky;
           top: 13.8rem;
           right: 0;
+          width: 100%;
         }
       `}
     >
@@ -64,7 +64,7 @@ const StudioInfo = ({ data, id }: IStudioInfo) => {
         <dl>
           <div>
             <dt>
-              <img src="/img/icon-clock.svg" alt="영업시간" />
+              <img className="img-time" src="/img/icon-clock.svg" alt="영업시간" />
             </dt>
             <dd>
               <div className="openStatus">
@@ -85,7 +85,7 @@ const StudioInfo = ({ data, id }: IStudioInfo) => {
 
           <div>
             <dt>
-              <img src="/img/icon-location.svg" alt="주소" />
+              <img className="img-address" src="/img/icon-location.svg" alt="주소" />
             </dt>
             <dd>
               <p>
@@ -97,7 +97,7 @@ const StudioInfo = ({ data, id }: IStudioInfo) => {
           </div>
           <div>
             <dt>
-              <img src="/img/icon-call-gray700.svg" alt="연락처" />
+              <img className="img-contact" src="/img/icon-call-gray700.svg" alt="연락처" />
             </dt>
             <dd>
               <p>{`${data.phone}`}</p>
@@ -118,11 +118,19 @@ const StudioInfoTitleStyle = css`
   display: flex;
   justify-content: space-between;
   margin-bottom: 1rem;
+  padding-top: 2rem;
 
   & > div {
+    min-width: 0;
+
     & > h2 {
       ${TypoTitleMdSb}
       margin-bottom: 0.4rem;
+
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      word-break: break-all;
     }
 
     & > .rating {
@@ -166,6 +174,7 @@ const StudioInfoTitleStyle = css`
 `;
 
 const SocialActionsStyle = css`
+  flex-shrink: 0;
   display: flex;
   gap: 2.4rem;
 `;
@@ -181,15 +190,31 @@ const StudioInfoStyle = ({ isPc }: { isPc: boolean }) => css`
 
     div {
       display: flex;
-      align-items: center;
+      gap: 0.8rem;
 
       dt {
+        flex-shrink: 0;
+        width: 2.6rem;
+        height: 2.6rem;
         display: flex;
-        margin-right: 1rem;
+        justify-content: center;
+        align-items: center;
 
         img {
-          width: 1.7rem;
-          height: 1.7rem;
+          &.img-time {
+            width: 1.7rem;
+            height: 1.7rem;
+          }
+
+          &.img-address {
+            width: 1.5rem;
+            height: 1.9rem;
+          }
+
+          &.img-contact {
+            width: 1.5rem;
+            height: 1.5rem;
+          }
         }
       }
 
@@ -198,19 +223,19 @@ const StudioInfoStyle = ({ isPc }: { isPc: boolean }) => css`
         align-items: center;
 
         p {
-          ${TypoBodyMdR}
+          ${TypoTitleXsR}
         }
 
         & > .openStatus {
           display: flex;
 
           & > p {
-            ${TypoBodyMdSb}
+            ${TypoTitleXsSb}
             margin-right: 0.8rem;
           }
 
           & > time {
-            ${TypoBodyMdR}
+            ${TypoTitleXsR}
           }
         }
       }

--- a/src/components/Studio/StudioInfoDock.tsx
+++ b/src/components/Studio/StudioInfoDock.tsx
@@ -18,13 +18,14 @@ const StudioInfoDock = () => {
       css={css`
         ${mqMin(breakPoints.pc)} {
           margin-left: auto;
+          margin-right: calc(-1 * ${variables.layoutPadding});
+          width: 42.4rem;
           flex-shrink: 0;
-          width: 37.6rem;
           background-color: ${variables.colors.white};
           box-shadow: inset 0.1rem 0 ${variables.colors.gray300};
           padding: 5.8rem ${variables.layoutPadding};
-          padding-right: 0;
-          z-index: 5;
+          box-sizing: border-box;
+          z-index: 9;
         }
       `}
     >


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#589

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 전체 너비 `42.4rem`으로 변경
- 상단 패딩 `2rem` 추가
- 주소 길어질 시 아이콘과 주소의 정렬이 깨지는 현상 방지
- 스튜디오 이름 길어질 시 `...` 처리
<img width="344" alt="image" src="https://github.com/user-attachments/assets/9ab3478c-a7d7-4126-9df9-fb10f7a34a34" />


<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
