### PR TITLE
[WEB2] 스튜디오 상세 탭 공통 적용

### DIFF
--- a/src/components/Navigator/StudioNavigator.tsx
+++ b/src/components/Navigator/StudioNavigator.tsx
@@ -60,7 +60,6 @@ const NavStyle = styled.nav`
   z-index: 5;
 
   ${mqMin(breakPoints.pc)} {
-    position: static;
     width: 36rem;
     margin: unset;
     padding: unset;

--- a/src/components/Studio/StudioInfo.tsx
+++ b/src/components/Studio/StudioInfo.tsx
@@ -118,7 +118,10 @@ const StudioInfoTitleStyle = css`
   display: flex;
   justify-content: space-between;
   margin-bottom: 1rem;
-  padding-top: 2rem;
+
+  ${mqMin(breakPoints.pc)} {
+    padding-top: 2rem;
+  }
 
   & > div {
     min-width: 0;

--- a/src/pages/Studio/StudioDetailLayout.tsx
+++ b/src/pages/Studio/StudioDetailLayout.tsx
@@ -1,16 +1,21 @@
 /** @jsxImportSource @emotion/react */
 import Loading from '@components/Loading/Loading';
+import StudioNavigator from '@components/Navigator/StudioNavigator';
 import StudioInfoDock from '@components/Studio/StudioInfoDock';
 import { css } from '@emotion/react';
 import { useGetStudioDetail } from '@hooks/useGetStudioDetail';
 import useStudioDataStore from '@store/useStudioDataStore';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
+import { bg100vw, PCLayout } from '@styles/Common';
+import variables from '@styles/Variables';
 import { useEffect } from 'react';
+import { useMediaQuery } from 'react-responsive';
 import { Outlet, useParams } from 'react-router-dom';
 
 const StudioDetailLayout = () => {
-  const { _id } = useParams();
+  const { _id } = useParams() as { _id: string };
   const { setStudioDetail } = useStudioDataStore();
+  const isPc = useMediaQuery({ minWidth: breakPoints.pc });
 
   const { data } = useGetStudioDetail(`${_id}`);
 
@@ -26,6 +31,7 @@ const StudioDetailLayout = () => {
         <main
           css={css`
             ${mqMin(breakPoints.pc)} {
+              ${PCLayout}
               display: flex;
               gap: 1.6rem;
             }
@@ -38,7 +44,39 @@ const StudioDetailLayout = () => {
               }
             `}
           >
-            <Outlet />
+            {isPc && (
+              <div
+                css={css`
+                  ${PCLayout}
+                  ${bg100vw(variables.colors.white)}
+                  background-color: ${variables.colors.white};
+                  position: fixed;
+                  top: 8rem;
+                  left: 0;
+                  right: 0;
+                  z-index: 9;
+                  padding-left: ${variables.layoutPadding};
+                  box-shadow: inset 0 -0.1rem ${variables.colors.gray300};
+
+                  ::before {
+                    left: 0;
+                    transform: translateX(-100%);
+                    box-shadow: inset 0 -0.1rem ${variables.colors.gray300};
+                  }
+                `}
+              >
+                <StudioNavigator _id={_id} />
+              </div>
+            )}
+            <div
+              css={css`
+                ${mqMin(breakPoints.pc)} {
+                  padding-top: 5.8rem;
+                }
+              `}
+            >
+              <Outlet />
+            </div>
           </section>
 
           {/* PC용 */}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#588 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- **PC버전에서** 스튜디오 상세 탭 공통 적용 (`StudioDetailLayout` 컴포넌트에 추가)
  - **PC버전에서** 기존 `<Outlet />`에 탭 높이만큼 `padding` 부여
<img width="1654" alt="image" src="https://github.com/user-attachments/assets/991d458b-9423-48ba-b77a-b725a58dac54" />


<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@woojoung1217 @HuiseonDev @s0zzang @kyungmim 

### PC버전에서 스튜디오 상세 탭을 공통 적용하고, 탭 높이만큼 여백을 확보해 두었으니, 기존에 불러오던 `StudioNavigator` 컴포넌트를 **모바일 환경**에서만 렌더링 되도록 각자 컴포넌트 수정 바랍니다.
