### PR TITLE
[WEB3] 예약 완료/취소 완료 화면 api 연동

### DIFF
--- a/src/hooks/useGetReservationData.ts
+++ b/src/hooks/useGetReservationData.ts
@@ -1,0 +1,46 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { IReservationData } from 'types/types';
+
+const ENDPOINT = `${import.meta.env.VITE_TOUCHEESE_API}/reservation/check`;
+
+const fetchReservationData = async (
+  _id: string,
+  accessToken: string,
+): Promise<IReservationData | undefined> => {
+  try {
+    const response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        reservationId: _id,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Failed to fetch data');
+
+    const data: IReservationData = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error);
+    }
+  }
+};
+
+export const useGetReservationData = (
+  _id: string,
+  accessToken: string,
+): UseQueryResult<IReservationData> => {
+  return useQuery({
+    queryKey: ['reservation', _id],
+    queryFn: () => fetchReservationData(_id, accessToken),
+    enabled: !!accessToken,
+    retry: 3,
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 3,
+    throwOnError: true,
+  });
+};

--- a/src/pages/Reservation/ReservationCanceled.tsx
+++ b/src/pages/Reservation/ReservationCanceled.tsx
@@ -1,29 +1,23 @@
-import { changeformatDateForUi, convertToDateFormat, today } from '@store/useSelectDateStore';
-import { useParams } from 'react-router-dom';
+import { useGetReservationData } from '@hooks/useGetReservationData';
+import useToast from '@hooks/useToast';
+import { useNavigate, useParams } from 'react-router-dom';
 import CompleteMessage from './components/CompleteMessage';
 
 const ReservationCanceled = () => {
   const { _id } = useParams() as { _id: string };
+  const userState = JSON.parse(localStorage.getItem('userState') || '{}');
+  const accessToken = userState.state.accessToken;
+  const openToast = useToast();
+  const navigate = useNavigate();
 
-  // 임시 데이터 => _id를 이용해 조회하도록 변경
-  const date = convertToDateFormat(today);
-  const time = ['13:00'];
+  const { data, error } = useGetReservationData(_id, accessToken);
 
-  const reservationData = {
-    id: Number(_id),
-    studio: '그믐달 스튜디오',
-    reservedDateTime: changeformatDateForUi({ date, time }),
-    reservedMenu: '프로필 A 반신 촬영',
-    options: [
-      { option_id: 1, optionPrice: 5000, optionName: '전체 컷 원본 파일' },
-      { option_id: 2, optionPrice: 5000, optionName: '전체 컷 원본 파일' },
-      { option_id: 3, optionPrice: 5000, optionName: '옵션 선택 1' },
-      { option_id: 4, optionPrice: 5000, optionName: '옵션 선택 2' },
-      { option_id: 5, optionPrice: 5000, optionName: '옵션 선택 3' },
-    ],
-  };
+  if (error) {
+    openToast('로그인 정보가 유효하지 않습니다! 다시 로그인해주세요!');
+    navigate('/user/auth');
+  }
 
-  return <CompleteMessage type="canceled" data={reservationData} resetInfo={() => {}} />;
+  return <>{data && <CompleteMessage type="canceled" data={data} resetInfo={() => {}} />}</>;
 };
 
 export default ReservationCanceled;

--- a/src/pages/Reservation/ReservationComplete.tsx
+++ b/src/pages/Reservation/ReservationComplete.tsx
@@ -1,44 +1,30 @@
+import { useGetReservationData } from '@hooks/useGetReservationData';
+import useToast from '@hooks/useToast';
 import useReservationStore from '@store/useReservationStore';
-import {
-  changeformatDateForUi,
-  convertToDateFormat,
-  today,
-  useSelectDateStore,
-} from '@store/useSelectDateStore';
+import { convertToDateFormat, today, useSelectDateStore } from '@store/useSelectDateStore';
 import { useSelectTimeStore } from '@store/useSelectTimeStore';
+import { useLocation, useNavigate } from 'react-router-dom';
 import CompleteMessage from './components/CompleteMessage';
-import { useLocation, useSearchParams } from 'react-router-dom';
 
 const ReservationComplete = () => {
-  const {
-    studioName: studio,
-    menuName: reservedMenu,
-    options,
-    clearReservationInfo,
-  } = useReservationStore();
-  const { date, setDate } = useSelectDateStore();
-  const { time, setTime } = useSelectTimeStore();
-
-  const [searchParams] = useSearchParams();
-  const reservationIdParam = searchParams.get('reservationId');
-  const reservationId = reservationIdParam ? Number(reservationIdParam) : 0;
-
-  const reservationData = {
-    id: reservationId,
-    studio,
-    reservedDateTime: changeformatDateForUi({ date, time }),
-    reservedMenu,
-    options,
-  };
-
+  const { clearReservationInfo } = useReservationStore();
+  const { setDate } = useSelectDateStore();
+  const { setTime } = useSelectTimeStore();
   const resetReservationInfo = () => {
     clearReservationInfo();
     setDate(convertToDateFormat(today));
     setTime('reset');
   };
 
+  const openToast = useToast();
+  const navigate = useNavigate();
   const location = useLocation();
+
+  const userState = JSON.parse(localStorage.getItem('userState') || '{}');
+  const accessToken = userState.state.accessToken;
+
   const query = new URLSearchParams(location.search);
+  const reservationId = query.get('reservationId');
   const resultCode = query.get('resultCode');
 
   if (resultCode === 'UserCancel') {
@@ -47,8 +33,19 @@ const ReservationComplete = () => {
     return null;
   }
 
+  if (!reservationId) {
+    throw new Error('예약 id가 없습니다!');
+  }
+
+  const { data, error } = useGetReservationData(reservationId, accessToken);
+
+  if (error) {
+    openToast('로그인 정보가 유효하지 않습니다! 다시 로그인해주세요!');
+    navigate('/user/auth');
+  }
+
   return (
-    <CompleteMessage type="reserved" data={reservationData} resetInfo={resetReservationInfo} />
+    <>{data && <CompleteMessage type="reserved" data={data} resetInfo={resetReservationInfo} />}</>
   );
 };
 

--- a/src/pages/Reservation/components/CompleteMessage.tsx
+++ b/src/pages/Reservation/components/CompleteMessage.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import Button from '@components/Button/Button';
 import styled from '@emotion/styled';
-import { ReservationOption } from '@store/useReservationStore';
+import { changeformatDateForUi, convertToDateFormat } from '@store/useSelectDateStore';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
 import {
   PCLayout,
@@ -14,17 +14,10 @@ import {
 } from '@styles/Common';
 import variables from '@styles/Variables';
 import { useNavigate } from 'react-router-dom';
+import { IReservationData } from 'types/types';
 
 interface IStepStyle {
   type: 'active' | 'inactive';
-}
-
-interface IData {
-  id: number;
-  studio: string | undefined;
-  reservedMenu: string | undefined;
-  reservedDateTime: string | null;
-  options: ReservationOption[];
 }
 
 const CompleteMessage = ({
@@ -33,14 +26,17 @@ const CompleteMessage = ({
   resetInfo,
 }: {
   type: 'reserved' | 'canceled';
-  data: IData;
+  data: IReservationData;
   resetInfo: () => void;
 }) => {
   const navigate = useNavigate();
 
-  const reservedOptions = data.options.map((option, index) => (
+  const date = convertToDateFormat(new Date(data.date));
+  const time = [`${data.startTime.split(':')[0]}:${data.startTime.split(':')[1]}`];
+
+  const reservedOptions = data.additionalMenuNames.map((additionalMenuName, index) => (
     <p key={index} css={TypoBodySmR} className="content-item-options">
-      {option.optionName}
+      {additionalMenuName}
     </p>
   ));
 
@@ -96,7 +92,7 @@ const CompleteMessage = ({
                 매장명
               </p>
               <div css={TypoBodyMdR} className="content-item-desc">
-                <p>{data.studio}</p>
+                <p>{data.studioName}</p>
               </div>
             </div>
             <div className="content-item">
@@ -104,7 +100,7 @@ const CompleteMessage = ({
                 일정
               </p>
               <div css={TypoBodyMdR} className="content-item-desc schedule">
-                <p>{data.reservedDateTime}</p>
+                <p>{changeformatDateForUi({ date, time })}</p>
               </div>
             </div>
             <div className="content-item">
@@ -113,7 +109,7 @@ const CompleteMessage = ({
               </p>
 
               <div css={TypoBodyMdR} className="content-item-desc menu">
-                <p>{data.reservedMenu}</p>
+                <p>{data.menuName}</p>
                 <div className="content-item-extra">{reservedOptions}</div>
               </div>
             </div>
@@ -123,17 +119,15 @@ const CompleteMessage = ({
       <FooterButtonStyle>
         <Button
           text={type === 'reserved' ? '예약 상세' : '취소 상세'}
-          variant="gray"
-          active={true}
+          variant="lightGray"
           onClick={() => {
             resetInfo();
-            navigate(`/reservation/${data.id}`, { replace: true });
+            navigate(`/reservation/${data.reservationId}`, { replace: true });
           }}
         />
         <Button
           text="홈으로"
           variant="black"
-          active={true}
           onClick={() => {
             resetInfo();
             navigate('/', { replace: true });
@@ -145,7 +139,7 @@ const CompleteMessage = ({
 };
 
 const SectionStyle = styled.section`
-  margin-top: 3.2rem;
+  margin-top: 7.2rem;
   padding-bottom: 10.6rem;
   display: flex;
   flex-direction: column;
@@ -153,9 +147,10 @@ const SectionStyle = styled.section`
 
   ${mqMin(breakPoints.pc)} {
     ${PCLayout}
-    padding: 0 32.8rem;
-    margin-top: 6.5rem;
+    width: 60.8rem;
+    margin-top: 6.05rem;
     margin-bottom: 2.4rem;
+    padding: 0 1.6rem;
     gap: 2.4rem;
   }
 `;
@@ -204,6 +199,9 @@ const ProgressStyle = styled.ul`
   align-items: center;
   justify-content: space-between;
   position: relative;
+  width: 100%;
+  max-width: 36.8rem;
+  margin: 0 auto;
 
   &::before {
     content: '';
@@ -232,7 +230,7 @@ const ProgressStyle = styled.ul`
   }
 
   ${mqMin(breakPoints.pc)} {
-    margin: 0 12rem;
+    margin: 0 10.4rem;
   }
 `;
 
@@ -312,6 +310,7 @@ const ReservationInfoStyle = styled.div`
             display: flex;
             flex-wrap: wrap;
             row-gap: 0.2rem;
+            color: ${variables.colors.gray900};
 
             & > .content-item-options {
               margin-right: 0.6rem;
@@ -338,7 +337,6 @@ const ReservationInfoStyle = styled.div`
 `;
 
 const FooterButtonStyle = styled.div`
-  box-shadow: inset 0 0 10px blue;
   z-index: 9;
   position: fixed;
   left: 0;
@@ -362,9 +360,9 @@ const FooterButtonStyle = styled.div`
 
   ${mqMin(breakPoints.pc)} {
     ${PCLayout}
-    padding: 0 32.8rem;
+    width: 60.8rem;
+    padding: 0 1.6rem;
     margin-bottom: 5.3rem;
-    box-shadow: inset 0 0 10px red;
     z-index: unset;
     position: unset;
     box-shadow: unset;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -210,3 +210,25 @@ export interface SortBy {
   RATING: string;
   REVIEW_COUNT: string;
 }
+
+export interface IReservationData {
+  reservationId: number;
+  studioId: number;
+  studioName: string;
+  startTime: string;
+  endTime: string;
+  menuId: number;
+  menuName: string;
+  additionalMenuIds: number[];
+  additionalMenuNames: string[];
+  additionalMenuPrices: number[];
+  userName: string;
+  userPhone: string;
+  note: string;
+  totalPrice: number;
+  status: 'WAITING' | 'RESERVED' | 'COMPLETED' | 'CANCELED';
+  date: string;
+  basicPrice: number;
+  paymentMethod: string;
+  menuImageUrl: string;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#590 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**[타입 추가]**
- 예약 상세 데이터 타입 지정 `IReservationData`

**[데이터 Fetching]**
- 예약 내역 조회 hook 설계 (@aksenmi 지민님 필요하시다면 사용하셔도 될 것 같아요!)

**[API 연동]**
- 스튜디오 예약 완료 화면 api 연동
  - `query`에서 `reservationId`를 받아서 예약 내역 조회
- 스튜디오 예약 취소 화면 api 연동
  - `params`에서 `_id`를 받아서 예약 내역 조회

**[UI 수정]**
- 스튜디오 예약 완료 화면 - 프로그레스 바 `width` 조정

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
