### PR TITLE
[WEB3] "메뉴 상세 - 예약 스케줄 선택 - 예약 결제" PC 레이아웃 개선 및 통일

### DIFF
--- a/src/components/ReservationFooter/ReservationFooter.tsx
+++ b/src/components/ReservationFooter/ReservationFooter.tsx
@@ -42,19 +42,6 @@ const ReservationFooter = ({
 
 export default ReservationFooter;
 
-export const reservationFooterWrStyle = css`
-  ${mqMin(breakPoints.pc)} {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: calc(100vh - ${variables.headerHeight});
-
-    .content-box {
-      overflow: hidden auto;
-    }
-  }
-`;
-
 const FixedBtnBoxStyle = css`
   display: flex;
   gap: 2rem;
@@ -84,6 +71,7 @@ const FixedBtnBoxStyle = css`
     }
   }
   ${mqMin(breakPoints.pc)} {
-    position: inherit;
+    position: sticky;
+    bottom: 0;
   }
 `;

--- a/src/pages/Home/components/SelectTime.tsx
+++ b/src/pages/Home/components/SelectTime.tsx
@@ -143,9 +143,6 @@ const SelectTimeStyle = (type: string) => css`
   padding-top: 3rem;
   ${mqMin(breakPoints.pc)} {
     padding-top: ${type === 'reservation' && '4.6rem'};
-    &::after {
-      width: ${type === 'reservation' && 'calc(100% + 9.6rem) !important'};
-    }
   }
 
   &::after {

--- a/src/pages/Reservation/ReservationCheck.tsx
+++ b/src/pages/Reservation/ReservationCheck.tsx
@@ -24,7 +24,6 @@ import { useUserStore } from '@store/useUserStore';
 import ReservationInfo from './components/ReservationInfo';
 import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
 import { pcFlexLayout } from './ReservationSchedule';
-import { reservationFooterWrStyle } from '@components/ReservationFooter/ReservationFooter';
 
 interface FormValues {
   visitorName: string;
@@ -127,7 +126,7 @@ const ReservationCheck = () => {
           <ReservationInfo />
         </div>
 
-        <div className="right-box" css={reservationFooterWrStyle}>
+        <div className="right-box">
           <div className="content-box">
             {' '}
             {/* 예약자정보 */}
@@ -657,7 +656,6 @@ const termsSectionStyle = css`
 
   ${mqMin(breakPoints.pc)} {
     padding-top: 3.4rem;
-    margin-bottom: -6rem;
   }
 
   &::before {

--- a/src/pages/Reservation/ReservationSchedule.tsx
+++ b/src/pages/Reservation/ReservationSchedule.tsx
@@ -65,6 +65,7 @@ export const pcFlexLayout = css`
       flex-grow: 1;
 
       .content-box {
+        min-height: calc(100vh - ${variables.headerHeight} - 8.1rem);
         padding: ${variables.headerBottomPadding} ${variables.layoutPadding};
       }
     }

--- a/src/pages/Reservation/ReservationSchedule.tsx
+++ b/src/pages/Reservation/ReservationSchedule.tsx
@@ -11,7 +11,6 @@ import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import ReservationInfo from './components/ReservationInfo';
 import ScheduleInner from './components/ScheduleInner';
-import { reservationFooterWrStyle } from '@components/ReservationFooter/ReservationFooter';
 
 const ReservationSchedule = () => {
   const { _id } = useParams() as { _id: string };
@@ -39,7 +38,7 @@ const ReservationSchedule = () => {
         <div className="left-box">
           <ReservationInfo />
         </div>
-        <div className="right-box" css={reservationFooterWrStyle}>
+        <div className="right-box">
           <ScheduleInner _id={_id} />
         </div>
       </div>
@@ -56,16 +55,17 @@ export const pcFlexLayout = css`
     align-content: flex-start;
 
     .left-box {
-      padding-top: ${variables.headerBottomPadding};
       width: 40%;
       max-width: 50.4rem;
+      position: sticky;
+      height: calc(100vh - ${variables.headerHeight} - ${variables.headerBottomPadding});
+      top: calc(${variables.headerHeight} + ${variables.headerBottomPadding});
     }
     .right-box {
       flex-grow: 1;
-      overflow: hidden;
 
       .content-box {
-        padding: ${variables.headerBottomPadding} ${variables.layoutPadding} 8rem;
+        padding: ${variables.headerBottomPadding} ${variables.layoutPadding};
       }
     }
   }

--- a/src/pages/Reservation/components/ScheduleInner.tsx
+++ b/src/pages/Reservation/components/ScheduleInner.tsx
@@ -65,6 +65,10 @@ const fixedBox = css`
     border-top: 1px solid ${variables.colors.gray300};
     background: #fff;
   }
+  ${mqMin(breakPoints.pc)} {
+    position: sticky;
+    bottom: 0;
+  }
 `;
 
 const finalDate = css`
@@ -79,8 +83,10 @@ const finalDate = css`
 
   // ReservationFooter
   & + div {
-    position: initial;
-    inset: unset;
+    ${mqMax(breakPoints.moMax)} {
+      position: initial;
+      inset: unset;
+    }
   }
 
   dl {

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 import useToast from '@hooks/useToast';
 import useReservationStore from '@store/useReservationStore';
 import { defaultUserState } from '@store/useUserStore';
-import { breakPoints, mqMin } from '@styles/BreakPoint';
+import { breakPoints, mqMax, mqMin } from '@styles/BreakPoint';
 import { TypoBodyMdM, TypoTitleSmS } from '@styles/Common';
 import variables from '@styles/Variables';
 import { getLocalStorageItem } from '@utils/getLocalStorageItem';
@@ -17,6 +17,7 @@ import { IMenuListRes, IPortfolio, IUser } from 'types/types';
 import { MenuPCStyle } from './StudioMenu';
 import StudioMenuDetailInfo from './StudioMenuDetailInfo';
 import StudioMenuDetailReview from './StudioMenuDetailReview';
+import { pcFlexLayout } from '@pages/Reservation/ReservationSchedule';
 
 const StudioMenuDetail = () => {
   const { _menuId, _id } = useParams();
@@ -135,9 +136,9 @@ const StudioMenuDetail = () => {
         />
       </div>
 
-      <div css={[MenuLayoutPCStyle]}>
+      <div css={[pcFlexLayout, menuDetailLayout]}>
         {data && (
-          <div css={MenuCoverStyle}>
+          <div className="left-box">
             <ImageSwiper
               images={data && data?.menuImages.length > 0 ? data?.menuImages : menuImgNopic}
               slidesPerView={1}
@@ -147,8 +148,8 @@ const StudioMenuDetail = () => {
           </div>
         )}
 
-        <div>
-          <div css={MenuInfoPCStyle} className="content-box">
+        <div className="right-box">
+          <div className="content-box">
             <div css={MenuDescStyle}>
               <h2>{data?.name}</h2>
               <p>{data?.description}</p>
@@ -182,40 +183,27 @@ const StudioMenuDetail = () => {
 
 export default StudioMenuDetail;
 
-const MenuLayoutPCStyle = css`
+const menuDetailLayout = css`
   ${mqMin(breakPoints.pc)} {
-    width: 100vw;
-    position: relative;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    gap: 3.5rem;
+    .left-box {
+      top: ${variables.headerHeight};
+      margin-left: calc(${variables.layoutPadding}*-1);
+      width: calc(40% + ${variables.layoutPadding});
+    }
+    .swiper-pagination.swiper-pagination-horizontal {
+      bottom: 3rem;
+    }
   }
 `;
 
-const MenuInfoPCStyle = css`
-  ${mqMin(breakPoints.pc)} {
-    padding: 5rem 2.4rem;
-    flex-grow: 1;
-  }
-`;
-
-const MenuCoverStyle = css`
-  ${mqMin(breakPoints.pc)} {
-    position: sticky;
-    left: 0;
-    top: 8rem;
-    width: 50.9rem;
-    height: 64rem;
-    z-index: 10;
-  }
-`;
 const MenuImgPCStyle = css`
+  ${mqMax(breakPoints.moMax)} {
+    aspect-ratio: 360/432;
+  }
   ${mqMin(breakPoints.pc)} {
     width: 100%;
-    height: 64rem;
-    object-fit: contain;
+    height: calc(100vh - ${variables.headerHeight});
+    max-height: 64rem;
   }
 `;
 
@@ -256,6 +244,7 @@ const TabMenuStyle = css`
   ${mqMin(breakPoints.pc)} {
     top: -5rem;
     width: calc(100% + (${variables.layoutPadding} * 2));
+    z-index: 1;
   }
 
   & li {

--- a/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetail.tsx
@@ -1,8 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import Header from '@components/Header/Header';
-import ReservationFooter, {
-  reservationFooterWrStyle,
-} from '@components/ReservationFooter/ReservationFooter';
+import ReservationFooter from '@components/ReservationFooter/ReservationFooter';
 import ImageSwiper from '@components/Swiper/ImageSwiper';
 import { css } from '@emotion/react';
 import useToast from '@hooks/useToast';
@@ -149,7 +147,7 @@ const StudioMenuDetail = () => {
           </div>
         )}
 
-        <div css={reservationFooterWrStyle}>
+        <div>
           <div css={MenuInfoPCStyle} className="content-box">
             <div css={MenuDescStyle}>
               <h2>{data?.name}</h2>

--- a/src/pages/Studio/StudioMenu/StudioMenuDetailInfo.tsx
+++ b/src/pages/Studio/StudioMenu/StudioMenuDetailInfo.tsx
@@ -204,7 +204,7 @@ const AddOptionsListStyle = css`
   gap: 2.4rem;
 
   ${mqMin(breakPoints.pc)} {
-    padding-bottom: 10rem;
+    padding-bottom: 3rem;
   }
 
   & li {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#634

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 예약 PC 레이아웃 변경 (flex -> sticky) : 스크롤 바 위치 변경(하위 콘텐츠 스크롤 -> body 스크롤)
  | 변경 이전 | 변경 이후 |
  | - | - |
  |  <img width="1036" alt="image" src="https://github.com/user-attachments/assets/2bc5e754-74bc-47db-99d8-622948e86d78" />  | <img width="1054" alt="image" src="https://github.com/user-attachments/assets/b2f96f7e-5699-4f2e-9642-6d27794d7843" />
- 예약 PC 레이아웃 content-box 최소 높이 지정 : 메뉴 상세 고려
- 예약 PC 레이아웃 메뉴 상세 적용

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@aksenmi 지민님 레이아웃 스타일 변경으로 불필요한 스타일 선언 삭제했습니다.
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/6ee20628-2438-4f06-b461-900effabfcec" />

<br />

@kyungmim 경민님 메뉴 상세에 예약 PC 공통 레이아웃을 적용하였으니 확인 부탁드립니다.
추가로 모바일에서 아래의 오류가 발생하여 `aspect-ratio` 설정하였습니다.
![image](https://github.com/user-attachments/assets/815c9b7f-094d-4c4f-9a4d-20297399842c)

