### PR TITLE
[S5] 내 리뷰 페이지 UI 및 반응형 구현

### DIFF
--- a/src/components/Navigator/ReservationNavigator.tsx
+++ b/src/components/Navigator/ReservationNavigator.tsx
@@ -1,22 +1,17 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
-import { ResStatus } from '@pages/Reservation/ReservationList';
 import { TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
 import { Dispatch, SetStateAction } from 'react';
 
-const STATUS: ResStatus[] = [
-  { statusKor: '이용 예정', statusEng: 'DEFAULT' },
-  { statusKor: '이용 완료', statusEng: 'COMPLETED' },
-  { statusKor: '예약 취소', statusEng: 'CANCELED' },
-];
-
-const ReservationNavigator = ({
+const ReservationNavigator = <T extends { statusKor: string; statusEng: string }>({
+  STATUS,
   status,
   setStatus,
 }: {
-  status: ResStatus;
-  setStatus: Dispatch<SetStateAction<ResStatus>>;
+  STATUS: T[];
+  status: T;
+  setStatus: Dispatch<SetStateAction<T>>;
 }) => {
   return (
     <nav>

--- a/src/components/ReservationCard/ReservationCard.tsx
+++ b/src/components/ReservationCard/ReservationCard.tsx
@@ -43,10 +43,10 @@ const ReservationCard = ({ isMyPage = false, data }: ReservationCardType) => {
           <div css={ReservationInfoStyle}>
             <div className="cardInfo">
               <StatusChip state={data.status} />
-              <p className="cardName">
-                {data.studioName} <span>|</span> {data.menuName}
-              </p>
-              <p className="cardDate">{`${convertToDateFormat(new Date(data.date))} (${getDay(new Date(data.date))}) ${data.startTime.split(':').slice(0, 2).join(':')}`}</p>
+              <div className="cardName">
+                <h3>{data.studioName}</h3> <span>|</span> <h4>{data.menuName}</h4>
+              </div>
+              <h4 className="cardDate">{`${convertToDateFormat(new Date(data.date))} (${getDay(new Date(data.date))}) ${data.startTime.split(':').slice(0, 2).join(':')}`}</h4>
             </div>
 
             <div className="cardCover">

--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -15,12 +15,17 @@ import { useMediaQuery } from 'react-responsive';
 import { useNavigate } from 'react-router-dom';
 import { IResvItem } from 'types/types';
 
-export interface ResStatus {
+interface ResStatus {
   statusKor: '이용 예정' | '이용 완료' | '예약 취소';
   statusEng: 'DEFAULT' | 'COMPLETED' | 'CANCELED';
 }
 
 const ReservationList = () => {
+  const STATUS: ResStatus[] = [
+    { statusKor: '이용 예정', statusEng: 'DEFAULT' },
+    { statusKor: '이용 완료', statusEng: 'COMPLETED' },
+    { statusKor: '예약 취소', statusEng: 'CANCELED' },
+  ];
   const [resStatus, setResStatus] = useState<ResStatus>({
     statusKor: '이용 예정',
     statusEng: 'DEFAULT',
@@ -76,21 +81,10 @@ const ReservationList = () => {
   }
 
   return (
-    <main
-      css={css`
-        ${PCLayout}
-        ${bg100vw(variables.colors.gray100)}
-      `}
-    >
-      <HeaderContainerStyle>
+    <main>
+      <MyPageHeaderContainerStyle>
         {isPc ? (
-          <div
-            css={css`
-              padding: 4rem 0 2rem;
-            `}
-          >
-            <h1 css={TypoTitleMdSb}>예약내역</h1>
-          </div>
+          <h1 className="pcLayout">예약내역</h1>
         ) : (
           <Header title="예약내역" backTo="/user/mypage" />
         )}
@@ -101,28 +95,19 @@ const ReservationList = () => {
             }
           `}
         >
-          <ReservationNavigator status={resStatus} setStatus={setResStatus} />
+          <ReservationNavigator<ResStatus>
+            STATUS={STATUS}
+            status={resStatus}
+            setStatus={setResStatus}
+          />
         </div>
-      </HeaderContainerStyle>
+      </MyPageHeaderContainerStyle>
 
-      <SectionStyle>
+      <MyPageSectionStyle>
         {items.length ? (
-          <ContentStyle>
-            <p css={TypoBodyMdM}>총 {items.length}건</p>
-            <div
-              css={css`
-                margin-top: 0.8rem;
-                display: flex;
-                flex-direction: column;
-                gap: 0.8rem;
-
-                ${mqMin(breakPoints.pc)} {
-                  margin-top: 1.6rem;
-                  display: grid;
-                  grid-template-columns: repeat(3, minmax(0, 1fr));
-                }
-              `}
-            >
+          <MyPageContentStyle>
+            <h2 css={TypoBodyMdM}>총 {items.length}건</h2>
+            <div className="content-box">
               {items
                 .sort((a, b) => {
                   // 1. date 비교
@@ -137,32 +122,34 @@ const ReservationList = () => {
                   <ReservationCard key={item.reservationId} data={item} />
                 ))}
             </div>
-          </ContentStyle>
+          </MyPageContentStyle>
         ) : (
           <NoResult message={emptyMessage} bg="gray100" />
         )}
-      </SectionStyle>
+      </MyPageSectionStyle>
     </main>
   );
 };
 
-const HeaderContainerStyle = styled.div`
+export const MyPageHeaderContainerStyle = styled.div`
   background-color: ${variables.colors.white};
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
+  z-index: 9;
+
+  .pcLayout {
+    ${TypoTitleMdSb}
+    padding: 4rem 0 2rem;
+  }
 
   ${mqMin(breakPoints.pc)} {
     ${PCLayout}
     ${bg100vw(variables.colors.white)}
     padding: 0 ${variables.layoutPadding};
-    box-shadow: inset 0 -0.1rem ${variables.colors.gray300};
     position: fixed;
     top: 8rem;
-    left: 0;
-    right: 0;
-    z-index: 9;
 
     &::before {
       box-shadow: inset 0 -0.1rem ${variables.colors.gray300};
@@ -170,12 +157,11 @@ const HeaderContainerStyle = styled.div`
   }
 `;
 
-const SectionStyle = styled.section`
+export const MyPageSectionStyle = styled.section`
+  ${bg100vw(variables.colors.gray100)}
   margin: 10rem calc(-1 * ${variables.layoutPadding}) calc(-1 * (4rem + ${variables.headerHeight}));
-  background-color: ${variables.colors.gray100};
   padding: 0 ${variables.layoutPadding} calc(4rem + ${variables.headerHeight});
   min-height: calc(100vh - 10rem);
-  overflow-y: auto;
 
   ${mqMin(breakPoints.pc)} {
     ${PCLayout}
@@ -188,8 +174,21 @@ const SectionStyle = styled.section`
   }
 `;
 
-const ContentStyle = styled.div`
+export const MyPageContentStyle = styled.div`
   padding-top: 2.4rem;
+
+  .content-box {
+    margin-top: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+
+    ${mqMin(breakPoints.pc)} {
+      margin-top: 1.6rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    }
+  }
 `;
 
 export default ReservationList;

--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -10,6 +10,7 @@ import useToast from '@hooks/useToast';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { bg100vw, PCLayout, TypoBodyMdM, TypoTitleMdSb } from '@styles/Common';
 import variables from '@styles/Variables';
+import { sortReservations } from '@utils/sortReservations';
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { useNavigate } from 'react-router-dom';
@@ -108,19 +109,9 @@ const ReservationList = () => {
           <MyPageContentStyle>
             <h2 css={TypoBodyMdM}>총 {items.length}건</h2>
             <div className="content-box">
-              {items
-                .sort((a, b) => {
-                  // 1. date 비교
-                  if (a.date !== b.date) {
-                    return a.date < b.date ? -1 : 1; // date가 빠른 순으로 정렬
-                  }
-
-                  // 2. startTime 비교 (date가 같을 때)
-                  return a.startTime < b.startTime ? -1 : 1;
-                })
-                .map((item) => (
-                  <ReservationCard key={item.reservationId} data={item} />
-                ))}
+              {sortReservations<IResvItem>(items).map((item) => (
+                <ReservationCard key={item.reservationId} data={item} />
+              ))}
             </div>
           </MyPageContentStyle>
         ) : (

--- a/src/pages/User/MyReviews.tsx
+++ b/src/pages/User/MyReviews.tsx
@@ -1,8 +1,85 @@
+/** @jsxImportSource @emotion/react */
+
+import Header from '@components/Header/Header';
+import ReservationNavigator from '@components/Navigator/ReservationNavigator';
+import ReservationCard from '@components/ReservationCard/ReservationCard';
+import { css } from '@emotion/react';
+import { useGetReservationList } from '@hooks/useGetReservationList';
+import {
+  MyPageContentStyle,
+  MyPageHeaderContainerStyle,
+  MyPageSectionStyle,
+} from '@pages/Reservation/ReservationList';
+import { breakPoints, mqMin } from '@styles/BreakPoint';
+import { TypoBodyMdM } from '@styles/Common';
+import { useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+
+interface MyReviewStatus {
+  statusKor: '리뷰 남기기' | '나의 리뷰';
+  statusEng: 'DEFAULT' | 'COMPLETED';
+}
+
 const MyReviews = () => {
+  const STATUS: MyReviewStatus[] = [
+    { statusKor: '리뷰 남기기', statusEng: 'COMPLETED' },
+    { statusKor: '나의 리뷰', statusEng: 'COMPLETED' },
+  ];
+  const [resStatus, setResStatus] = useState<MyReviewStatus>({
+    statusKor: '리뷰 남기기',
+    statusEng: 'COMPLETED',
+  });
+  const isPc = useMediaQuery({ minWidth: breakPoints.pc });
+
+  const { data } = useGetReservationList('COMPLETED');
+
   return (
-    <>
-      <h1>나의 리뷰페이지</h1>
-    </>
+    <main>
+      <MyPageHeaderContainerStyle>
+        {isPc ? (
+          <h1 className="pcLayout">내 리뷰</h1>
+        ) : (
+          <Header title="내 리뷰" backTo="/user/mypage" />
+        )}
+
+        <div
+          css={css`
+            ${mqMin(breakPoints.pc)} {
+              width: 20.7rem;
+            }
+          `}
+        >
+          <ReservationNavigator<MyReviewStatus>
+            STATUS={STATUS}
+            status={resStatus}
+            setStatus={setResStatus}
+          />
+        </div>
+      </MyPageHeaderContainerStyle>
+
+      <MyPageSectionStyle>
+        {data && (
+          <MyPageContentStyle>
+            <h2 css={TypoBodyMdM}>총 {data.length}건</h2>
+            <div className="content-box">
+              {data
+                .sort((a, b) => {
+                  // 1. date 비교
+                  if (a.date !== b.date) {
+                    return a.date < b.date ? -1 : 1; // date가 빠른 순으로 정렬
+                  }
+
+                  // 2. startTime 비교 (date가 같을 때)
+                  return a.startTime < b.startTime ? -1 : 1;
+                })
+                .map((item) => (
+                  <ReservationCard key={item.reservationId} data={item} />
+                ))}
+            </div>
+          </MyPageContentStyle>
+        )}
+      </MyPageSectionStyle>
+    </main>
   );
 };
 

--- a/src/utils/sortReservations.tsx
+++ b/src/utils/sortReservations.tsx
@@ -1,0 +1,16 @@
+interface ReservationItem {
+  date: string;
+  startTime: string;
+}
+
+export const sortReservations = <T extends ReservationItem>(items: T[]): T[] => {
+  return items.sort((a, b) => {
+    // 1. date 비교
+    if (a.date !== b.date) {
+      return a.date < b.date ? -1 : 1; // date가 빠른 순으로 정렬
+    }
+
+    // 2. startTime 비교 (date가 같을 때)
+    return a.startTime < b.startTime ? -1 : 1;
+  });
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#639 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 예약 내역 - 공통 사용을 위한 추상화
- 제네릭 타입 적용 및 전달
- 스타일 export
- 예약 내역 정렬 유틸 분리

### 내 리뷰
- UI 구현
- 예외처리 - 로그인 세션 만료 안내

### 기타
- 예약카드: 스튜디오 이름, 예약 일시 헤딩 태그로 변경 (h3, h4)

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@JWJung-99 진욱님, 예약 내역 페이지 추상화를 진행하였습니다. 확인 부탁드립니다.
@kyungmim 경민님, 예약 카드 내 태그 변경하였습니다. 확인 부탁드립니다.