### PR TITLE
[Hotfix] 403 에러로 로그인 페이지 이동 시 발생하는 토스트 렌더링 경고 해결

### DIFF
--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -39,14 +39,16 @@ const ReservationList = () => {
   // resStatus 변경 시 api 호출
   const { data, error } = useGetReservationList(resStatus.statusEng);
 
-  if (error) {
-    if (error.message === '403') {
-      openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
-      navigate('/user/auth');
-    } else {
-      throw new Error(error.message);
+  useEffect(() => {
+    if (error) {
+      if (error.message === '403') {
+        openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
+        navigate('/user/auth');
+      } else {
+        throw new Error(error.message);
+      }
     }
-  }
+  }, [error]);
 
   // resStatus 변경 시 아이템 초기화
   useEffect(() => {

--- a/src/pages/User/BookmarkedStudios.tsx
+++ b/src/pages/User/BookmarkedStudios.tsx
@@ -7,7 +7,7 @@ import useToast from '@hooks/useToast';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { bg100vw, Hidden, PCLayout, TypoTitleMdSb } from '@styles/Common';
 import variables from '@styles/Variables';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { useNavigate } from 'react-router-dom';
 import BookmarkedStudioList from './components/BookmarkedStudioList';
@@ -22,14 +22,16 @@ const BookmarkedStudios = () => {
 
   const { data, error, refetch } = useGetBookmarkList(activeTheme);
 
-  if (error) {
-    if (error.message === '403') {
-      openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
-      navigate('/user/auth');
-    } else {
-      throw new Error(error.message);
+  useEffect(() => {
+    if (error) {
+      if (error.message === '403') {
+        openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
+        navigate('/user/auth');
+      } else {
+        throw new Error(error.message);
+      }
     }
-  }
+  }, [error]);
 
   // 선택한 테마의 탭 UI를 활성화하고, 북마크 목록을 갱신
   const handleTheme = (theme: Theme) => {

--- a/src/pages/User/MyPage.tsx
+++ b/src/pages/User/MyPage.tsx
@@ -31,14 +31,16 @@ const MyPage = () => {
 
   const { data, error } = useGetReservationList('RESERVED');
 
-  if (error) {
-    if (error.message === '403') {
-      openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
-      navigate('/user/auth');
-    } else {
-      throw new Error(error.message);
+  useEffect(() => {
+    if (error) {
+      if (error.message === '403') {
+        openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
+        navigate('/user/auth');
+      } else {
+        throw new Error(error.message);
+      }
     }
-  }
+  }, [error]);
 
   // 현재 날짜와 예약 날짜 비교 함수
   const filterReservations = data?.filter((item) => {

--- a/src/pages/User/MyReviews.tsx
+++ b/src/pages/User/MyReviews.tsx
@@ -14,7 +14,7 @@ import {
 import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { TypoBodyMdM } from '@styles/Common';
 import { sortReservations } from '@utils/sortReservations';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { useNavigate } from 'react-router-dom';
 import { IResvItem } from 'types/types';
@@ -36,14 +36,16 @@ const MyReviews = () => {
   const openToast = useToast();
   const navigate = useNavigate();
 
-  if (error) {
-    if (error.message === '403') {
-      openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
-      navigate('/user/auth');
-    } else {
-      throw new Error(error.message);
+  useEffect(() => {
+    if (error) {
+      if (error.message === '403') {
+        openToast('로그인 세션이 만료되었습니다. 다시 로그인 해주세요!');
+        navigate('/user/auth');
+      } else {
+        throw new Error(error.message);
+      }
     }
-  }
+  }, [error]);
 
   return (
     <main>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#659

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 403 에러로 로그인 페이지 이동 시 발생하는 토스트 렌더링 경고 해결

  - 페이지 렌더링 중 `openToast`를 호출해서 발생하는 문제로, `error`를 의존성 배열에 담은 `useEffect`를 사용해 렌더링 이후에 `Toast`의 상태를 변경하도록 수정

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
