### PR TITLE
[WEB1] PC버전 필터 영역 변경으로 인한 컨텐츠 정렬

### DIFF
--- a/src/components/BookingSearchContainer/BookingButton.tsx
+++ b/src/components/BookingSearchContainer/BookingButton.tsx
@@ -28,7 +28,8 @@ const BookingButton = ({ type }: { type: 'mo' | 'pc' }) => {
       onClick={() => modal.open()}
       css={css`
         ${mqMin(breakPoints.pc)} {
-          margin: 1.1rem 0 1.2rem;
+          width: 15.6rem;
+          margin: 1.1rem 3.6rem 1.2rem 0;
         }
       `}
     >
@@ -55,6 +56,9 @@ const BookingButton = ({ type }: { type: 'mo' | 'pc' }) => {
                 font-size: 1.2rem;
                 font-weight: 500;
                 line-height: 1.4rem;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
               `
         }
       >

--- a/src/components/Header/PCHeader.tsx
+++ b/src/components/Header/PCHeader.tsx
@@ -38,6 +38,7 @@ export default PCHeader;
 
 const HeaderStyle = css`
   ${mqMin(breakPoints.pc)} {
+    ${PCLayout}
     position: fixed;
     top: 0;
     left: 0;
@@ -51,18 +52,16 @@ const HeaderStyle = css`
 
 const HeaderContentsStyle = css`
   ${mqMin(breakPoints.pc)} {
-    ${PCLayout}
-
     display: flex;
-    gap: 1.6rem;
+    gap: 3.2rem;
     align-items: center;
     padding: 1rem ${variables.layoutPadding};
   }
 `;
 
 const logoContainerStyle = css`
+  width: 28rem;
   flex-shrink: 0;
-  flex-grow: 1;
 `;
 
 const homeLogoStyle = css`
@@ -77,7 +76,8 @@ const homeLogoStyle = css`
 `;
 
 const inputContainerStyle = css`
-  flex-grow: 2;
+  flex-grow: 1;
+  max-width: 60.8rem;
   display: flex;
   align-items: center;
 `;
@@ -88,7 +88,7 @@ const inputStyle = css`
 `;
 
 const buttonContainerStyle = css`
-  flex-grow: 1;
+  margin-left: auto;
   flex-shrink: 0;
   display: flex;
 `;

--- a/src/components/Studio/StudioItem.tsx
+++ b/src/components/Studio/StudioItem.tsx
@@ -45,7 +45,7 @@ const StudioItem = ({
     const portfolios = isPc ? photos.slice(0, 7) : photos.slice(0, 5);
 
     portfolios.forEach((photo: IPortfolio) => {
-      images.push(photo.url);
+      images.push(photo.url.replace(/\.jpeg$/, '.webp'));
     });
 
     return images;

--- a/src/components/Studio/StudioItem.tsx
+++ b/src/components/Studio/StudioItem.tsx
@@ -68,8 +68,8 @@ const StudioItem = ({
                 <img
                   key={`${item.id}-image-${index}`}
                   css={css`
-                    width: 14rem;
-                    aspect-ratio: 140 / 176;
+                    width: calc((100% - 12px) / 7);
+                    aspect-ratio: 127 / 160;
                   `}
                   src={image}
                   alt={`이미지 ${index + 1}`}
@@ -85,7 +85,7 @@ const StudioItem = ({
                 object-fit: cover;
 
                 ${mqMin(breakPoints.pc)} {
-                  aspect-ratio: 140 / 176;
+                  aspect-ratio: 141 / 177;
                 }
               `}
             />
@@ -136,6 +136,7 @@ const StudioItem = ({
 };
 
 const DivStyle = styled.div<{ isFirst: boolean; isLast: boolean }>`
+  width: 100%;
   padding: 1.6rem 0;
   border-bottom: 1px solid ${variables.colors.gray300};
 
@@ -150,8 +151,21 @@ const DivStyle = styled.div<{ isFirst: boolean; isLast: boolean }>`
   }
 
   ${mqMin(breakPoints.pc)} {
-    padding: 3.4rem 0;
+    padding: unset;
+    padding-bottom: 3.4rem;
     border-bottom: unset;
+
+    ${({ isFirst }) =>
+      isFirst &&
+      `
+        padding-top: 3rem;
+    `}
+
+    ${({ isLast }) =>
+      isLast &&
+      `
+        padding-bottom: unset;
+    `}
   }
 `;
 
@@ -160,6 +174,7 @@ const ItemImageStyle = styled.div`
 
   ${mqMin(breakPoints.pc)} {
     margin-bottom: 1rem;
+    width: 100%;
   }
 `;
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -330,6 +330,7 @@ const ListStyle = styled.div`
   ${mqMin(breakPoints.pc)} {
     padding: unset;
     padding-right: 1.6rem;
+    padding-bottom: 3rem;
     flex-grow: 1;
   }
 `;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -150,12 +150,18 @@ const Home = () => {
               ${bg100vw(variables.colors.black)}
               display: flex;
               align-items: center;
-              gap: 5.2rem;
+              gap: 1.6rem;
               padding: 0 ${variables.layoutPadding};
             }
           `}
         >
-          <BookingButton type="pc" />
+          <div
+            css={css`
+              width: 28rem;
+            `}
+          >
+            <BookingButton type="pc" />
+          </div>
           <ThemeNavigator />
         </div>
 
@@ -314,7 +320,7 @@ const FilterSectionStyle = styled.div<IFixedProps>`
   position: sticky;
   top: 13.8rem;
   left: 0;
-  width: 27.4rem;
+  width: 28rem;
   height: calc(100vh - 13.8rem);
 `;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#658

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 필터 영역 `280px`로 변경에 따라 검색창 / 테마 탭 / 스튜디오 목록의 정렬 수정
  <img width="50%" alt="image" src="https://github.com/user-attachments/assets/b41ddbf5-275b-4e9f-80ed-ac67e50a6319" />

- 이미지 크기 `width: calc((100% - 12px) / 7); aspect-ratio: 127 / 160;` 수정을 통해 이미지 영역의 뷰포트 초과 방지
  <img width="50%" alt="image" src="https://github.com/user-attachments/assets/ee84ded1-a755-41c4-9124-4a83f80c46a2" />


<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- @s0zzang 필터 영역 너비를 `27.4rem`에서 `28rem`으로 변경했습니다. 변경 내용 확인 부탁드려요!
