### PR TITLE
[QA] PC버전 전체 레이아웃 하단 여백 추가 및 그에 따른 기존 여백 삭제

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -322,6 +322,7 @@ const FilterSectionStyle = styled.div<IFixedProps>`
   left: 0;
   width: 28rem;
   height: calc(100vh - 13.8rem);
+  margin-bottom: -3rem;
 `;
 
 const ListStyle = styled.div`
@@ -330,7 +331,6 @@ const ListStyle = styled.div`
   ${mqMin(breakPoints.pc)} {
     padding: unset;
     padding-right: 1.6rem;
-    padding-bottom: 3rem;
     flex-grow: 1;
   }
 `;

--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -90,7 +90,11 @@ const ReservationList = () => {
         <title>예약 내역 - {resStatus.statusKor}</title>
         <meta property="og:title" content={`예약 내역 - ${resStatus.statusKor} `} />
       </Helmet>
-      <main>
+      <main
+        css={css`
+          margin-bottom: -3rem;
+        `}
+      >
         <MyPageHeaderContainerStyle>
           {isPc ? (
             <h1 className="pcLayout">예약내역</h1>
@@ -159,6 +163,8 @@ export const MyPageHeaderContainerStyle = styled.div`
 `;
 
 export const MyPageSectionStyle = styled.section`
+  box-shadow: inset 0 0 20px blue;
+
   ${bg100vw(variables.colors.gray100)}
   margin: 10rem calc(-1 * ${variables.layoutPadding}) calc(-1 * (4rem + ${variables.headerHeight}));
   padding: 0 ${variables.layoutPadding} calc(4rem + ${variables.headerHeight});

--- a/src/pages/User/BookmarkedStudios.tsx
+++ b/src/pages/User/BookmarkedStudios.tsx
@@ -72,7 +72,6 @@ const BookmarkedStudios = () => {
         <section
           css={css`
             margin-top: 10rem;
-            padding-bottom: 3rem;
 
             ${mqMin(breakPoints.pc)} {
               margin-top: 13.85rem;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -47,7 +47,7 @@ const GlobalStyles = css`
 
     @media (min-width: ${breakPoints.pc}) {
       padding-top: ${variables.headerHeight};
-      padding-bottom: 0;
+      padding-bottom: 3rem;
     }
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#681 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- PC버전 전체 레이아웃 하단 여백 `3rem` 추가
- 홈, 예약 내역, 찜한 사진관 등에서 부여한 하단 여백 삭제

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@woojoung1217 @HuiseonDev @aksenmi @s0zzang @kyungmim PC버전 전체에 하단 패딩 `3rem` 추가하였으니 혹시 개인적으로 주신 분들은 삭제 바랍니다
