### PR TITLE
[QA] 스튜디오 상세 페이지 진입 시 발생하는 무한로딩 문제 해결

### DIFF
--- a/src/components/Studio/StudioInfoDock.tsx
+++ b/src/components/Studio/StudioInfoDock.tsx
@@ -6,14 +6,11 @@ import { useParams } from 'react-router-dom';
 import StudioInfo from './StudioInfo';
 import { IStudioDetail } from 'types/types';
 
-const StudioInfoDock = () => {
+const StudioInfoDock = ({ data }: { data: IStudioDetail }) => {
   const { _id } = useParams();
-  const studioData = sessionStorage.getItem('studio-storage');
-  const parsedData = studioData ? JSON.parse(studioData) : null;
-  const data: IStudioDetail = parsedData?.state.studioDetail[Number(_id)];
 
   return (
-    <aside
+    <div
       className="pc"
       css={css`
         ${mqMin(breakPoints.pc)} {
@@ -23,8 +20,8 @@ const StudioInfoDock = () => {
         }
       `}
     >
-      {data && <StudioInfo data={data} id={_id} />}
-    </aside>
+      <StudioInfo data={data} id={_id} />
+    </div>
   );
 };
 

--- a/src/components/Studio/StudioInfoDock.tsx
+++ b/src/components/Studio/StudioInfoDock.tsx
@@ -17,15 +17,9 @@ const StudioInfoDock = () => {
       className="pc"
       css={css`
         ${mqMin(breakPoints.pc)} {
-          margin-left: auto;
-          margin-right: calc(-1 * ${variables.layoutPadding});
-          width: 42.4rem;
-          flex-shrink: 0;
+          width: 100%;
+          margin-right: calc(${variables.layoutPadding});
           background-color: ${variables.colors.white};
-          box-shadow: inset 1px 0 ${variables.colors.gray300};
-          padding: 5.8rem ${variables.layoutPadding};
-          box-sizing: border-box;
-          z-index: 9;
         }
       `}
     >

--- a/src/pages/Studio/StudioDetailLayout.tsx
+++ b/src/pages/Studio/StudioDetailLayout.tsx
@@ -4,26 +4,16 @@ import StudioNavigator from '@components/Navigator/StudioNavigator';
 import StudioInfoDock from '@components/Studio/StudioInfoDock';
 import { css } from '@emotion/react';
 import { useGetStudioDetail } from '@hooks/useGetStudioDetail';
-import useStudioDataStore from '@store/useStudioDataStore';
 import { breakPoints, mqMin } from '@styles/BreakPoint';
 import { bg100vw, PCLayout } from '@styles/Common';
 import variables from '@styles/Variables';
-import { useEffect } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { Outlet, useParams } from 'react-router-dom';
 
 const StudioDetailLayout = () => {
   const { _id } = useParams() as { _id: string };
-  const { setStudioDetail } = useStudioDataStore();
   const isPc = useMediaQuery({ minWidth: breakPoints.pc });
-
-  const { data } = useGetStudioDetail(`${_id}`);
-
-  useEffect(() => {
-    if (data) {
-      setStudioDetail(`${_id}`, data);
-    }
-  }, [data]);
+  const { data } = useGetStudioDetail(_id);
 
   return (
     <>
@@ -45,26 +35,7 @@ const StudioDetailLayout = () => {
             `}
           >
             {isPc && (
-              <div
-                css={css`
-                  ${PCLayout}
-                  ${bg100vw(variables.colors.white)}
-                  background-color: ${variables.colors.white};
-                  position: fixed;
-                  top: 8rem;
-                  left: 0;
-                  right: 0;
-                  z-index: 9;
-                  padding-left: ${variables.layoutPadding};
-                  box-shadow: inset 0 -1px ${variables.colors.gray300};
-
-                  ::before {
-                    left: 0;
-                    transform: translateX(-100%);
-                    box-shadow: inset 0 -1px ${variables.colors.gray300};
-                  }
-                `}
-              >
+              <div css={navStyle}>
                 <StudioNavigator _id={_id} type="pcOnly" />
               </div>
             )}
@@ -75,31 +46,14 @@ const StudioDetailLayout = () => {
                 }
               `}
             >
-              <Outlet />
+              <Outlet context={isPc && data} />
             </div>
           </section>
 
           {/* PC용 */}
-          <div
-            css={css`
-              flex-shrink: 0;
-              position: sticky;
-              top: 8rem;
-              right: 0;
-              width: 42.4rem;
-              height: calc(100vh - 8rem);
-              z-index: 9;
-              padding-top: 5.8rem;
-              padding-left: ${variables.layoutPadding};
-              margin-right: calc(-1 * ${variables.layoutPadding});
-              margin-bottom: -3rem;
-              background-color: ${variables.colors.white};
-              box-shadow: inset 1px 0 ${variables.colors.gray300};
-              box-sizing: border-box;
-            `}
-          >
-            <StudioInfoDock />
-          </div>
+          <aside css={dockStyle}>
+            <StudioInfoDock data={data} />
+          </aside>
         </main>
       ) : (
         <Loading size="big" phrase="스튜디오 정보를 불러오고 있습니다." />
@@ -109,3 +63,39 @@ const StudioDetailLayout = () => {
 };
 
 export default StudioDetailLayout;
+
+const navStyle = css`
+  ${PCLayout}
+  ${bg100vw(variables.colors.white)}
+background-color: ${variables.colors.white};
+  position: fixed;
+  top: 8rem;
+  left: 0;
+  right: 0;
+  z-index: 9;
+  padding-left: ${variables.layoutPadding};
+  box-shadow: inset 0 -1px ${variables.colors.gray300};
+
+  ::before {
+    left: 0;
+    transform: translateX(-100%);
+    box-shadow: inset 0 -1px ${variables.colors.gray300};
+  }
+`;
+
+const dockStyle = css`
+  flex-shrink: 0;
+  position: sticky;
+  top: 8rem;
+  right: 0;
+  width: 42.4rem;
+  height: calc(100vh - 8rem);
+  z-index: 9;
+  padding-top: 5.8rem;
+  padding-left: ${variables.layoutPadding};
+  margin-right: calc(-1 * ${variables.layoutPadding});
+  margin-bottom: -3rem;
+  background-color: ${variables.colors.white};
+  box-shadow: inset 1px 0 ${variables.colors.gray300};
+  box-sizing: border-box;
+`;

--- a/src/pages/Studio/StudioDetailLayout.tsx
+++ b/src/pages/Studio/StudioDetailLayout.tsx
@@ -80,7 +80,26 @@ const StudioDetailLayout = () => {
           </section>
 
           {/* PC용 */}
-          <StudioInfoDock />
+          <div
+            css={css`
+              flex-shrink: 0;
+              position: sticky;
+              top: 8rem;
+              right: 0;
+              width: 42.4rem;
+              height: calc(100vh - 8rem);
+              z-index: 9;
+              padding-top: 5.8rem;
+              padding-left: ${variables.layoutPadding};
+              margin-right: calc(-1 * ${variables.layoutPadding});
+              margin-bottom: -3rem;
+              background-color: ${variables.colors.white};
+              box-shadow: inset 1px 0 ${variables.colors.gray300};
+              box-sizing: border-box;
+            `}
+          >
+            <StudioInfoDock />
+          </div>
         </main>
       ) : (
         <Loading size="big" phrase="스튜디오 정보를 불러오고 있습니다." />

--- a/src/pages/Studio/StudioMain/StudioMain.tsx
+++ b/src/pages/Studio/StudioMain/StudioMain.tsx
@@ -2,7 +2,6 @@
 import Button from '@components/Button/Button';
 import Header from '@components/Header/Header';
 import KakaoMap from '@components/Kakao/KakaoMap';
-import Loading from '@components/Loading/Loading';
 import StudioNavigator from '@components/Navigator/StudioNavigator';
 import StudioInfo from '@components/Studio/StudioInfo';
 import StudioOptions from '@components/Studio/StudioOptions';
@@ -13,7 +12,7 @@ import variables from '@styles/Variables';
 import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useMediaQuery } from 'react-responsive';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { IStudioDetail } from 'types/types';
 
 const StudioMain = () => {
@@ -26,14 +25,7 @@ const StudioMain = () => {
   const handleClick = () => navigate(`/studio/${_id}/menu`);
   const isPc = useMediaQuery({ minWidth: breakPoints.pc });
 
-  const [studioData, setStudioData] = useState<IStudioDetail>();
-
-  useEffect(() => {
-    const sessionData = sessionStorage.getItem('studio-storage');
-    if (sessionData) {
-      setStudioData(JSON.parse(sessionData).state.studioDetail[`${_id}`]);
-    }
-  }, [_id]);
+  const studioData = useOutletContext<IStudioDetail>();
 
   const descRef = useRef<HTMLParagraphElement>(null);
   const [hasMore, setHasMore] = useState(false);
@@ -91,10 +83,6 @@ const StudioMain = () => {
         () => false,
       );
   };
-
-  if (!studioData) {
-    return <Loading size="big" phrase="스튜디오를 불러오고 있습니다." />;
-  }
 
   /** 이미지 5개 이하일 때 대체할 이미지 */
   const placeHolderImageList = [


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#683

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- StudioInfoDock의 높이 지정
- PC 헤더와 StudioInfoDock의 z-index 수정
- 스튜디오 상세 페이지 진입 시 발생하는 무한로딩 문제 해결
  - 기존 세션 스토리지에서 data를 호출하는 방식은 Strict 모드가 아닌 배포 버전에서는 동작하지 않아 문제 발생
  - React-Router Outlet이 제공하는 `context`에 data를 props 형태로 전달하고, 하위의 `StudioMain` 컴포넌트에서 `useOutletContext`를 활용해 data를 받아서 사용
    <img width="620" alt="image" src="https://github.com/user-attachments/assets/67263f65-309a-48b8-b759-b9066475986d" />


<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
