### PR TITLE
[QA] 필터링 정렬의 UI를 개선한다

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css, CSSObject, keyframes } from '@emotion/react';
-import { PCLayout, TypoBodyMdM, TypoBodyMdR, TypoBodySmM, TypoTitleXsM } from '@styles/Common';
+import { PCLayout, TypoBodyMdM, TypoBodyMdR, TypoBodySmR, TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
 import React, { useState } from 'react';
 
@@ -34,6 +34,7 @@ interface ButtonProps {
   iconSizeHeight?: string;
   style?: CSSObject;
   dataTab?: string;
+  iconGap?: string;
 }
 
 /**  버튼 컴포넌트 사용
@@ -60,6 +61,7 @@ interface ButtonProps {
 
 const Button = ({
   icon,
+  iconGap = '0.8rem',
   iconSizeWidth = '2rem',
   iconSizeHeight = '2rem',
   iconPosition = 'non',
@@ -145,7 +147,7 @@ const Button = ({
   const iconWrapperStyles = css`
     display: flex;
     align-items: center;
-    gap: 0.8rem;
+    gap: ${iconGap};
 
     ${iconPosition === 'right' && `flex-direction: row-reverse;`}
     ${iconPosition === 'left' && ` flex-direction: row;`}
@@ -155,9 +157,9 @@ const Button = ({
   // ----------------------------- 버튼 사이즈 -----------------------------
   const sizeStyles = {
     xsmall: css`
-      ${TypoBodySmM};
+      ${TypoBodySmR};
       height: 3.2rem;
-      padding: 0 1rem;
+      padding: 0.6rem 1rem;
     `,
     small: css`
       ${TypoBodyMdR};

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -43,6 +43,7 @@ const Filter = ({ text, onClick, params, paramsKeyword, paramsName }: FilterProp
       size="xsmall"
       width="fit"
       icon={<img src="/img/icon-arrowdown.svg" alt="닫기 아이콘" />}
+      iconGap="0.5rem"
       iconSizeWidth="1.1rem"
       iconSizeHeight="0.6rem"
       iconPosition="right"

--- a/src/components/Filter/FilterSort.tsx
+++ b/src/components/Filter/FilterSort.tsx
@@ -104,6 +104,7 @@ const DropdownWrapper = styled.div`
 
 const DropdownList = styled.ul`
   position: absolute;
+  margin-top: 0.6rem;
   top: -1px;
   width: 100%;
   background: white;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #708 


<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 버튼 공통 컴포넌트의 gap 사이즈 커스터마이징 기능 추가
- PC 필터링 정렬 버튼의 드롭다운 박스 간격 적용
- MO 필터링 버튼의 내부 아이콘 gap 사이즈 수정

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
-  @woojoung1217 @JWJung-99 @aksenmi @s0zzang @kyungmim 
버튼 컴포넌트에 아이콘과 텍스트 `gap`사이즈 커스터마이징 기능 적용해두었습니다! 아이콘이 있는 경우 텍스트와 기본 `gap` 사이즈는 `0.8rem` 입니다. 수정이 필요하신 분들은 `iconGap="0.5rem"` 형태로 `prop` 하시면 됩니다!
