### PR TITLE
[QA] 예약 카드 마크업 변경

### DIFF
--- a/src/components/ReservationCard/ReservationCard.tsx
+++ b/src/components/ReservationCard/ReservationCard.tsx
@@ -3,10 +3,10 @@ import { css } from '@emotion/react';
 import { convertToDateFormat, getDay } from '@store/useSelectDateStore';
 import { TypoBodyMdM, TypoBodySmR, TypoTitleXsM } from '@styles/Common';
 import variables from '@styles/Variables';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { IResvItem } from 'types/types';
 import RatingReview from './RatingReview';
 import StatusChip from './StatusChip';
-import { IResvItem } from 'types/types';
 
 type ReservationCardType = {
   isMyPage?: boolean;
@@ -19,7 +19,6 @@ const ReservationCard = ({
   isReviewWritePage = false,
   data,
 }: ReservationCardType) => {
-  const navigate = useNavigate();
   const { pathname } = useLocation();
 
   //방문 날짜 계산 함수
@@ -36,10 +35,7 @@ const ReservationCard = ({
   return (
     <>
       {data ? (
-        <a
-          css={CardStyle(isMyPage)}
-          onClick={() => navigate(`/reservation/${data?.reservationId}`)}
-        >
+        <a href={`/reservation/${data?.reservationId}`} css={CardStyle(isMyPage)}>
           {isMyPage && (
             <div css={CardTopStyle}>
               <img src="/img/icon-calendar-yellow.svg" alt="일정 d-day 아이콘" />
@@ -89,15 +85,13 @@ const ReservationCard = ({
           )}
         </a>
       ) : (
-        <article css={EmptyCardStyle}>
+        <div css={EmptyCardStyle}>
           <p>
             예약하신 사진관이 없습니다. <br />
             매장을 예약하고 인생 사진을 찍어보세요!
           </p>
-          <button type="button" onClick={() => navigate('/')}>
-            사진관 보러가기
-          </button>
-        </article>
+          <a href="/">사진관 보러가기</a>
+        </div>
       )}
     </>
   );
@@ -106,6 +100,7 @@ const ReservationCard = ({
 export default ReservationCard;
 
 const CardStyle = (isMyPage: boolean | undefined) => css`
+  display: block;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -198,7 +193,7 @@ const EmptyCardStyle = css`
     ${TypoBodyMdM}
   }
 
-  & button {
+  & a {
     display: flex;
     gap: 0.4rem;
     padding: 0.8rem 1rem;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#735

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 예약 카드의 마크업을 `article` → `a` 태그로 변경해 탭 컨트롤 활성화
  - ReservationCard
    <img width="498" alt="image" src="https://github.com/user-attachments/assets/5faca2f4-76bb-4d29-9c6f-6c3ecc08bb83" />

  - EmptyCard
    <img width="471" alt="image" src="https://github.com/user-attachments/assets/4a272d8b-2b22-498a-b265-363b5af91a6b" />


<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
