### PR TITLE
[S4] 소셜 로그인 로직 추가

### DIFF
--- a/src/pages/User/AuthVerification.tsx
+++ b/src/pages/User/AuthVerification.tsx
@@ -9,7 +9,8 @@ import { Hidden, TypoTitleMdSb } from '@styles/Common';
 import { useLayoutEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useForm } from 'react-hook-form';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { ISocialData } from 'types/types';
 
 interface AuthVerificationType {
   success: boolean;
@@ -38,6 +39,10 @@ const AuthVerification = () => {
   const storageName = parsedData?.state?.username || '';
   const storagePhone = parsedData?.state?.phone || '';
 
+  // 소셜 로그인 데이터
+  const location = useLocation();
+  const socialData: ISocialData = location.state;
+
   const {
     register,
     handleSubmit,
@@ -62,8 +67,38 @@ const AuthVerification = () => {
     }
   }, []);
 
-  const handleSave = (data: any) => {
-    setSignupData(data);
+  const handleSave = async (data: any) => {
+    if (!socialData) {
+      // 이메일 회원가입인 경우 인증 후 가입 페이지로 이동
+      setSignupData(data);
+      navigate('/user/signup');
+    } else {
+      // 소셜 회원가입인 경우 인증 후 회원가입 api 호출!
+      const formData = {
+        userName: storageName,
+        email: socialData.r_email,
+        password: socialData.r_password,
+        phone: storagePhone,
+        registration: socialData.r_registration,
+      };
+
+      try {
+        const response = await fetch(`${import.meta.env.VITE_TOUCHEESE_API}/auth/register`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(formData),
+        });
+
+        if (!response.ok) {
+          throw new Error(`서버 오류: ${response.status}`);
+        }
+        navigate('/user/signupSuccess');
+      } catch (error) {
+        console.error('회원가입 중 오류 발생:', error);
+      }
+    }
   };
 
   /** 간편 본인인증 실행 함수 */
@@ -162,7 +197,6 @@ const AuthVerification = () => {
 
         <div css={buttonStyle}>
           <Button
-            onClick={() => navigate('/user/signup')}
             type="submit"
             width="max"
             text="다음"

--- a/src/pages/User/GoogleCallback.tsx
+++ b/src/pages/User/GoogleCallback.tsx
@@ -1,4 +1,5 @@
 import Loading from '@components/Loading/Loading';
+import useToast from '@hooks/useToast';
 import { useUserStore } from '@store/useUserStore';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +9,7 @@ const GoogleCallback = () => {
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
   const setUser = useUserStore((state) => state.setUser);
+  const openToast = useToast();
 
   useEffect(() => {
     const codeParams = new URLSearchParams(window.location.search).get('code');
@@ -42,6 +44,7 @@ const GoogleCallback = () => {
 
       if (data.accessToken) {
         setUser(data);
+        openToast('로그인 성공!');
         navigate('/', { replace: true });
       } else {
         navigate('/user/AuthVerification', {

--- a/src/pages/User/GoogleCallback.tsx
+++ b/src/pages/User/GoogleCallback.tsx
@@ -1,8 +1,13 @@
+import Loading from '@components/Loading/Loading';
+import { useUserStore } from '@store/useUserStore';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const GoogleCallback = () => {
   const [code, setCode] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const setUser = useUserStore((state) => state.setUser);
 
   useEffect(() => {
     const codeParams = new URLSearchParams(window.location.search).get('code');
@@ -10,8 +15,6 @@ const GoogleCallback = () => {
     if (codeParams) {
       setCode(codeParams);
     }
-
-    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -36,17 +39,25 @@ const GoogleCallback = () => {
       );
 
       const data = await response.json();
-      console.log(data);
+
+      if (data.accessToken) {
+        setUser(data);
+        navigate('/', { replace: true });
+      } else {
+        navigate('/user/AuthVerification', {
+          replace: true,
+          state: data,
+        });
+      }
+
+      setIsLoading(false);
     } catch (err) {
-      console.error(err);
+      console.error('구글 로그인 에러', err);
+      navigate('/user/auth');
     }
   };
 
-  if (loading) {
-    return <div>로그인 중...</div>;
-  }
-
-  return <div>로그인 완료</div>;
+  return <>{isLoading && <Loading size="big" phrase="로그인 중입니다..." />}</>;
 };
 
 export default GoogleCallback;

--- a/src/pages/User/KakaoCallback.tsx
+++ b/src/pages/User/KakaoCallback.tsx
@@ -1,3 +1,4 @@
+import useToast from '@hooks/useToast';
 import { useUserStore } from '@store/useUserStore';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -5,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 const KakaoCallback = () => {
   const navigate = useNavigate();
   const setUser = useUserStore((state) => state.setUser);
+  const openToast = useToast();
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
@@ -30,6 +32,7 @@ const KakaoCallback = () => {
 
         if (result.accessToken) {
           setUser(result);
+          openToast('로그인 성공!');
           navigate('/', { replace: false });
         } else {
           navigate('/user/AuthVerification', {

--- a/src/pages/User/KakaoCallback.tsx
+++ b/src/pages/User/KakaoCallback.tsx
@@ -1,8 +1,10 @@
+import { useUserStore } from '@store/useUserStore';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const KakaoCallback = () => {
   const navigate = useNavigate();
+  const setUser = useUserStore((state) => state.setUser);
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
@@ -25,20 +27,19 @@ const KakaoCallback = () => {
         );
 
         const result = await response.json();
-        console.log('result: 필요함', result);
 
-        if (result.status.length > 1) {
-          navigate('/user/AuthVerification', {
-            state: {
-              status: result,
-            },
-          });
+        if (result.accessToken) {
+          setUser(result);
+          navigate('/', { replace: false });
         } else {
-          navigate('/');
+          navigate('/user/AuthVerification', {
+            replace: false,
+            state: result,
+          });
         }
       } catch (error) {
         console.error('카카오 로그인 에러:', error);
-        navigate('/login');
+        navigate('/user/auth');
       }
     };
 

--- a/src/pages/User/signupSuccess.tsx
+++ b/src/pages/User/signupSuccess.tsx
@@ -10,7 +10,7 @@ const SignupSuccess = () => {
   const navigate = useNavigate();
 
   const handleLogin = () => {
-    navigate('/login');
+    navigate('/user/auth');
   };
 
   return (

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,3 +235,11 @@ export interface IReservationData {
   paymentMethod: string;
   menuImageUrl: string;
 }
+
+export interface ISocialData {
+  r_email: string;
+  r_password: string;
+  r_registration: string;
+  r_username: string | null;
+  status: string;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#351 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

@woojoung1217 
- 카카오 로그인 실행 시
  - 처음 가입하는 계정이라면 `/user/Authverification`으로 이동하여 본인인증 후 가입처리
  - 이미 가입한 계정이라면 `userStore`에 데이터 저장 후 로그인처리

@HuiseonDev 
- Authverification에서 **다음**버튼 클릭 시
  - 소셜 회원가입이라면 회원 가입 api 호출 후 성공 시 `/user/signupSuccess`로 이동
  - 이메일 회원가입이라면 `/user/signup`으로 이동