### PR TITLE
[QA] 소셜 로그인/회원가입 로직 수정

### DIFF
--- a/src/pages/User/AuthVerification.tsx
+++ b/src/pages/User/AuthVerification.tsx
@@ -35,6 +35,7 @@ const AuthVerification = () => {
   const navigate = useNavigate();
   const [isActive, setIsActive] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
+  const [isVerified, setIsVerified] = useState(false);
 
   const storedData = sessionStorage.getItem('signup-storage');
   const parsedData = storedData ? JSON.parse(storedData) : null;
@@ -75,6 +76,10 @@ const AuthVerification = () => {
       setSignupData(data);
       navigate('/user/signup');
     } else {
+      if (!isVerified) {
+        return;
+      }
+
       // 소셜 회원가입인 경우 인증 후 회원가입 api 호출!
       const formData = {
         userName: storageName,
@@ -96,7 +101,10 @@ const AuthVerification = () => {
         if (!response.ok) {
           throw new Error(`서버 오류: ${response.status}`);
         }
-        navigate('/user/signupSuccess');
+
+        if (response.ok) {
+          navigate('/user/signupSuccess');
+        }
       } catch (error) {
         console.error('회원가입 중 오류 발생:', error);
       }
@@ -122,6 +130,7 @@ const AuthVerification = () => {
             setIsActive(true);
             setIsDisabled(false);
             setSignupData({ username: storageName, phone: storagePhone });
+            setIsVerified(true);
 
             // 비동기적으로 reset 호출 (setState 후 화면이 렌더링된 후 reset)
             setTimeout(() => {

--- a/src/pages/User/AuthVerification.tsx
+++ b/src/pages/User/AuthVerification.tsx
@@ -71,15 +71,15 @@ const AuthVerification = () => {
   }, []);
 
   const handleSave = async (data: any) => {
+    if (!isVerified) {
+      return;
+    }
+
     if (!socialData) {
       // 이메일 회원가입인 경우 인증 후 가입 페이지로 이동
       setSignupData(data);
       navigate('/user/signup');
     } else {
-      if (!isVerified) {
-        return;
-      }
-
       // 소셜 회원가입인 경우 인증 후 회원가입 api 호출!
       const formData = {
         userName: storageName,

--- a/src/pages/User/GoogleCallback.tsx
+++ b/src/pages/User/GoogleCallback.tsx
@@ -1,66 +1,7 @@
-import Loading from '@components/Loading/Loading';
-import useToast from '@hooks/useToast';
-import { useUserStore } from '@store/useUserStore';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import SocialCallback from './components/SocialCallback';
 
 const GoogleCallback = () => {
-  const [code, setCode] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const navigate = useNavigate();
-  const setUser = useUserStore((state) => state.setUser);
-  const openToast = useToast();
-
-  useEffect(() => {
-    const codeParams = new URLSearchParams(window.location.search).get('code');
-
-    if (codeParams) {
-      setCode(codeParams);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (code) {
-      handleLogin(code);
-    }
-  }, [code]);
-
-  const handleLogin = async (code: string) => {
-    try {
-      const response = await fetch(
-        `${import.meta.env.VITE_TOUCHEESE_API}/user/auth/google/callback`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            code,
-          }),
-        },
-      );
-
-      const data = await response.json();
-
-      if (data.accessToken) {
-        setUser(data);
-        openToast('로그인 성공!');
-        navigate('/', { replace: true });
-      } else {
-        navigate('/user/AuthVerification', {
-          replace: true,
-          state: data,
-        });
-      }
-
-      setIsLoading(false);
-    } catch (err) {
-      console.error('구글 로그인 에러', err);
-      navigate('/user/auth');
-    }
-  };
-
-  return <>{isLoading && <Loading size="big" phrase="로그인 중입니다..." />}</>;
+  return <SocialCallback type="google" />;
 };
 
 export default GoogleCallback;

--- a/src/pages/User/KakaoCallback.tsx
+++ b/src/pages/User/KakaoCallback.tsx
@@ -1,55 +1,7 @@
-import useToast from '@hooks/useToast';
-import { useUserStore } from '@store/useUserStore';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import SocialCallback from './components/SocialCallback';
 
 const KakaoCallback = () => {
-  const navigate = useNavigate();
-  const setUser = useUserStore((state) => state.setUser);
-  const openToast = useToast();
-
-  useEffect(() => {
-    const code = new URL(window.location.href).searchParams.get('code');
-
-    const handleKakaoLogin = async () => {
-      try {
-        if (!code) {
-          throw new Error('인증 코드를 찾을 수 없습니다.');
-        }
-
-        const response = await fetch(
-          `${import.meta.env.VITE_TOUCHEESE_API}/user/auth/kakao/callback`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ code }),
-          },
-        );
-
-        const result = await response.json();
-
-        if (result.accessToken) {
-          setUser(result);
-          openToast('로그인 성공!');
-          navigate('/', { replace: false });
-        } else {
-          navigate('/user/AuthVerification', {
-            replace: false,
-            state: result,
-          });
-        }
-      } catch (error) {
-        console.error('카카오 로그인 에러:', error);
-        navigate('/user/auth');
-      }
-    };
-
-    handleKakaoLogin();
-  }, [navigate]);
-
-  return <div>로그인 처리중...</div>;
+  return <SocialCallback type="kakao" />;
 };
 
 export default KakaoCallback;

--- a/src/pages/User/components/SocialCallback.tsx
+++ b/src/pages/User/components/SocialCallback.tsx
@@ -1,0 +1,66 @@
+import Loading from '@components/Loading/Loading';
+import useToast from '@hooks/useToast';
+import { useUserStore } from '@store/useUserStore';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SocialCallback = ({ type }: { type: 'kakao' | 'google' }) => {
+  const [code, setCode] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const setUser = useUserStore((state) => state.setUser);
+  const openToast = useToast();
+
+  useEffect(() => {
+    const codeParams = new URLSearchParams(window.location.search).get('code');
+
+    if (codeParams) {
+      setCode(codeParams);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (code) {
+      handleLogin(code);
+    }
+  }, [code]);
+
+  const handleLogin = async (code: string) => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_TOUCHEESE_API}/user/auth/${type}/callback`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            code,
+          }),
+        },
+      );
+
+      const data = await response.json();
+
+      if (data.accessToken) {
+        setUser(data);
+        openToast('로그인 성공!');
+        navigate('/', { replace: true });
+      } else {
+        navigate('/user/AuthVerification', {
+          replace: true,
+          state: data,
+        });
+      }
+
+      setIsLoading(false);
+    } catch (err) {
+      console.error(`${type === 'kakao' ? '카카오' : '구글'} 로그인 에러`, err);
+      navigate('/user/auth');
+    }
+  };
+
+  return <>{isLoading && <Loading size="big" phrase="로그인 중입니다..." />}</>;
+};
+
+export default SocialCallback;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#760 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `Authverification` (@HuiseonDev)
  - 소셜 회원가입 시 "인증하기" 버튼을 클릭하면 `/user/signupSuccess` 페이지로 이동하는 문제 발생
  
    ∵ `handleAuth` 함수의 response가 오기 전에 `handleSave` 함수가 호출되기 때문
    
    ⇒ `isVerified` 상태를 추가하여 `handleAuth` 함수의 response가 success일 때만 `true`로 변경하고, `isVerified`가 `false`라면 `handleSave`를 `return`하도록 변경 


- `KakaoCallback`과 `GoogleCallback` 코드가 거의 유사하여 `SocialCallback` 공통 컴포넌트를 생성하고 `type: "kakao" | "google"`을 이용하여 구분

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
