### PR TITLE
[QA] 예약 관련 스타일 및 로직 수정

### DIFF
--- a/src/pages/Reservation/ReservationList.tsx
+++ b/src/pages/Reservation/ReservationList.tsx
@@ -84,6 +84,16 @@ const ReservationList = () => {
       break;
   }
 
+  const compareDate = (date: string) => {
+    const itemDate = new Date(date);
+    const today = new Date();
+
+    itemDate.setHours(0, 0, 0, 0);
+    today.setHours(0, 0, 0, 0);
+
+    return itemDate.getTime() >= today.getTime();
+  };
+
   return (
     <>
       <Helmet>
@@ -121,7 +131,11 @@ const ReservationList = () => {
             <MyPageContentStyle>
               <h2 css={TypoBodyMdM}>총 {items.length}건</h2>
               <div className="content-box">
-                {sortReservations<IResvItem>(items).map((item) => (
+                {sortReservations<IResvItem>(
+                  resStatus.statusEng === 'DEFAULT'
+                    ? items.filter((item) => compareDate(item.date))
+                    : items,
+                ).map((item) => (
                   <ReservationCard key={item.reservationId} data={item} />
                 ))}
               </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#766 

<br>

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `ReservationList`
  - 이용 예정 예약 내역에서, 이미 날짜가 지난 예약 내역은 렌더링 하지 않는 것으로 로직 변경

- `MyPage`
  - 마이페이지 레이아웃 수정
  - 마이페이지 예약 내역 스와이퍼 슬라이드 개수 분기 처리
    - `isPc === true`
      - 예약 확정 데이터가 있다면 3개
      - 데이터가 없다면 1개 (사진관을 예약해보세요!)
      <br />

      |데이터가 있을 때|데이터가 없을 때|
      |:--:|:--:|
      |<img width="1223" alt="image" src="https://github.com/user-attachments/assets/414a0040-dbe7-4e27-987d-af7d6b510e83" />|<img width="1215" alt="image" src="https://github.com/user-attachments/assets/90ab0f7f-e3be-4a0d-ab40-d2bb2653787b" />|


    - `isPc === false`
      - 1개
      <br />

      |모바일|
      |:--:|
      |<img width="293" alt="image" src="https://github.com/user-attachments/assets/9d287b06-47fe-4b1a-bf18-3b297df3db9c" />|

<br>

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
